### PR TITLE
Scaffold modern React SDK foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .DS_STORE
 build
 node_modules
-package-lock.json
 scripts/flow/*/.flowconfig
 *~
 *.pyc
@@ -11,6 +10,7 @@ __benchmarks__
 build/
 remote-repo/
 coverage/
+packages/react-sdk/dist/
 .module-cache
 fixtures/dom/public/react-dom.js
 fixtures/dom/public/react.js

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "dev": "webpack --mode development",
     "watch": "webpack --mode development --progress --watch",
     "build": "webpack --mode production",
-    "start": "webpack-dev-server --mode development --open --hot --progress --watch"
+    "start": "webpack-dev-server --mode development --open --hot --progress --watch",
+    "react-sdk:build": "npm --prefix packages/react-sdk run build",
+    "react-sdk:dev": "npm --prefix packages/react-sdk run dev",
+    "react-sdk:typecheck": "npm --prefix packages/react-sdk run typecheck"
   },
   "keywords": [],
   "author": "",

--- a/packages/react-sdk/README.md
+++ b/packages/react-sdk/README.md
@@ -1,0 +1,64 @@
+# @gafa/theme-react-sdk
+
+Foundation for the next GFTheme SDK: a modern, embeddable React package that can run beside the legacy SDK while new widgets are migrated view by view.
+
+## What is included
+
+- Vite + React + TypeScript library build.
+- `createGafaSdk(...)` runtime API.
+- Legacy-compatible bootstrap for current `data-gf-theme` containers.
+- Typed config parser for both modern config and current `data-gf-options`.
+- Brand theme tokens mapped to scoped CSS variables.
+- Initial mobile-first widgets for calendar, catalog, auth, profile, and purchase buttons.
+- Mock client for local development and a legacy `window.GafaFitSDK` adapter seam.
+
+## Programmatic usage
+
+```ts
+import { createGafaSdk } from "@gafa/theme-react-sdk";
+
+const sdk = createGafaSdk({
+  apiBaseUrl: "https://example.gafa.fit",
+  companyId: 1,
+  publicClientId: "public-client",
+  theme: {
+    preset: "boutique",
+    logoUrl: "https://example.com/logo.svg",
+    colors: {
+      primary: "#111827",
+      accent: "#f97316",
+    },
+  },
+});
+
+sdk.mountCalendar("#calendar");
+sdk.mountCatalog("#packages", { type: "packages" });
+sdk.mountAuth("#auth", { initialView: "login" });
+sdk.mountProfile("#profile");
+```
+
+## Legacy-compatible usage
+
+```ts
+import { bootstrapLegacyWidgets, createGafaSdk, readLegacyOptionsFromDom } from "@gafa/theme-react-sdk";
+
+const sdk = createGafaSdk(readLegacyOptionsFromDom());
+bootstrapLegacyWidgets(sdk);
+```
+
+This maps current containers such as:
+
+```html
+<section data-gf-theme="meetings-calendar" filter-bq-location="true"></section>
+<section data-gf-theme="combo-list" data-gf-filterbyname="starter"></section>
+```
+
+## Development
+
+```sh
+npm run dev
+npm run typecheck
+npm run build
+```
+
+The current API client intentionally returns mock data unless a host injects the legacy `window.GafaFitSDK`. The next implementation step is to replace the mock client with real gafa.fit/gafa.pay HTTP adapters.

--- a/packages/react-sdk/README.md
+++ b/packages/react-sdk/README.md
@@ -12,6 +12,10 @@ Foundation for the next GFTheme SDK: a modern, embeddable React package that can
 - Initial mobile-first widgets for calendar, catalog, auth, profile, and purchase buttons.
 - Mock client for local development and a legacy `window.GafaFitSDK` adapter seam.
 
+## Calendar scope
+
+The first calendar implementation already loads brands, locations, services, staff, and meetings through the `GafaClient` contract. It supports the legacy filter attributes, groups meetings by day, displays availability, and keeps the mobile layout as the default experience.
+
 ## Programmatic usage
 
 ```ts

--- a/packages/react-sdk/index.html
+++ b/packages/react-sdk/index.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>GFTheme React SDK</title>
+  </head>
+  <body>
+    <script type="application/json" data-gf-options>
+      {
+        "GAFA_FIT_URL": "https://example.com",
+        "COMPANY_ID": 1,
+        "API_CLIENT": "public-client",
+        "BRAND_ID": 1,
+        "THEME": {
+          "preset": "default",
+          "colors": {
+            "primary": "#111827",
+            "accent": "#f97316"
+          },
+          "logoUrl": "https://dummyimage.com/120x40/111827/ffffff&text=GAFA"
+        }
+      }
+    </script>
+
+    <main style="display: grid; gap: 24px; padding: 24px;">
+      <section data-gf-theme="meetings-calendar" filter-bq-location="true" filter-bq-service="true"></section>
+      <section data-gf-theme="combo-list" data-gf-filterbyname=""></section>
+      <section data-gf-theme="login-register" data-gf-initial="login"></section>
+      <section data-gf-theme="profile-info"></section>
+      <button
+        data-gf-theme="purchase-button"
+        data-bq-combo-id="1"
+        data-bq-location-id="1"
+        type="button"
+      >
+        Comprar paquete
+      </button>
+      <section data-gf-theme="fancy"></section>
+    </main>
+
+    <script type="module" src="/src/legacy/auto.ts"></script>
+  </body>
+</html>

--- a/packages/react-sdk/index.html
+++ b/packages/react-sdk/index.html
@@ -3,42 +3,61 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>GFTheme React SDK</title>
+    <title>GFTheme React SDK Preview</title>
+    <style>
+      body {
+        background: #f8fafc;
+        margin: 0;
+      }
+
+      .demo-shell {
+        display: grid;
+        gap: 24px;
+        margin: 0 auto;
+        max-width: 980px;
+        padding: 20px;
+      }
+
+      .demo-hero {
+        background: linear-gradient(135deg, #111827, #f97316);
+        border-radius: 28px;
+        color: #ffffff;
+        display: grid;
+        gap: 8px;
+        padding: 28px 22px;
+      }
+
+      .demo-hero p,
+      .demo-hero h1 {
+        margin: 0;
+      }
+
+      .demo-hero h1 {
+        font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        font-size: clamp(2rem, 10vw, 4rem);
+        line-height: 0.95;
+      }
+
+      .demo-hero p {
+        color: rgba(255, 255, 255, 0.78);
+        font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+    </style>
   </head>
   <body>
-    <script type="application/json" data-gf-options>
-      {
-        "GAFA_FIT_URL": "https://example.com",
-        "COMPANY_ID": 1,
-        "API_CLIENT": "public-client",
-        "BRAND_ID": 1,
-        "THEME": {
-          "preset": "default",
-          "colors": {
-            "primary": "#111827",
-            "accent": "#f97316"
-          },
-          "logoUrl": "https://dummyimage.com/120x40/111827/ffffff&text=GAFA"
-        }
-      }
-    </script>
+    <main class="demo-shell">
+      <section class="demo-hero">
+        <p>GFTheme React SDK</p>
+        <h1>Preview mobile-first</h1>
+        <p>Calendario, paquetes, login y perfil con branding configurable.</p>
+      </section>
 
-    <main style="display: grid; gap: 24px; padding: 24px;">
-      <section data-gf-theme="meetings-calendar" filter-bq-location="true" filter-bq-service="true"></section>
-      <section data-gf-theme="combo-list" data-gf-filterbyname=""></section>
-      <section data-gf-theme="login-register" data-gf-initial="login"></section>
-      <section data-gf-theme="profile-info"></section>
-      <button
-        data-gf-theme="purchase-button"
-        data-bq-combo-id="1"
-        data-bq-location-id="1"
-        type="button"
-      >
-        Comprar paquete
-      </button>
-      <section data-gf-theme="fancy"></section>
+      <section id="calendar-demo"></section>
+      <section id="packages-demo"></section>
+      <section id="auth-demo"></section>
+      <section id="profile-demo"></section>
     </main>
 
-    <script type="module" src="/src/legacy/auto.ts"></script>
+    <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/packages/react-sdk/index.html
+++ b/packages/react-sdk/index.html
@@ -5,26 +5,45 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>GFTheme React SDK Preview</title>
     <style>
+      :root {
+        color-scheme: light;
+        font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
       body {
-        background: #f8fafc;
+        background:
+          radial-gradient(circle at top left, rgba(249, 115, 22, 0.18), transparent 32rem),
+          linear-gradient(180deg, #fff7ed 0%, #f8fafc 42%, #eef2ff 100%);
+        color: #111827;
         margin: 0;
+        min-height: 100vh;
       }
 
       .demo-shell {
         display: grid;
-        gap: 24px;
+        gap: 18px;
         margin: 0 auto;
-        max-width: 980px;
-        padding: 20px;
+        max-width: 760px;
+        padding: 18px 14px 36px;
       }
 
       .demo-hero {
-        background: linear-gradient(135deg, #111827, #f97316);
-        border-radius: 28px;
+        background:
+          radial-gradient(circle at 82% 16%, rgba(255, 255, 255, 0.32), transparent 9rem),
+          linear-gradient(135deg, #111827 0%, #1f2937 42%, #f97316 100%);
+        border: 1px solid rgba(255, 255, 255, 0.2);
+        border-radius: 34px;
+        box-shadow: 0 24px 60px rgba(15, 23, 42, 0.22);
         color: #ffffff;
         display: grid;
-        gap: 8px;
-        padding: 28px 22px;
+        gap: 16px;
+        overflow: hidden;
+        padding: 26px 22px;
+        position: relative;
       }
 
       .demo-hero p,
@@ -33,28 +52,86 @@
       }
 
       .demo-hero h1 {
-        font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-        font-size: clamp(2rem, 10vw, 4rem);
+        font-size: clamp(2.4rem, 12vw, 4.5rem);
+        letter-spacing: -0.07em;
         line-height: 0.95;
       }
 
       .demo-hero p {
-        color: rgba(255, 255, 255, 0.78);
-        font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        color: rgba(255, 255, 255, 0.8);
+        font-size: 1rem;
+        line-height: 1.45;
+      }
+
+      .demo-hero__eyebrow {
+        align-items: center;
+        display: flex;
+        font-size: 0.78rem;
+        font-weight: 800;
+        gap: 8px;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+
+      .demo-hero__eyebrow::before {
+        background: #f97316;
+        border-radius: 999px;
+        content: "";
+        height: 9px;
+        width: 9px;
+      }
+
+      .demo-hero__chips {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+      }
+
+      .demo-hero__chips span {
+        background: rgba(255, 255, 255, 0.14);
+        border: 1px solid rgba(255, 255, 255, 0.22);
+        border-radius: 999px;
+        color: rgba(255, 255, 255, 0.88);
+        font-size: 0.78rem;
+        font-weight: 750;
+        padding: 7px 11px;
+      }
+
+      .demo-grid {
+        display: grid;
+        gap: 18px;
+      }
+
+      @media (min-width: 760px) {
+        .demo-shell {
+          gap: 22px;
+          padding: 28px;
+        }
+
+        .demo-grid {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
       }
     </style>
   </head>
   <body>
     <main class="demo-shell">
       <section class="demo-hero">
-        <p>GFTheme React SDK</p>
-        <h1>Preview mobile-first</h1>
-        <p>Calendario, paquetes, login y perfil con branding configurable.</p>
+        <p class="demo-hero__eyebrow">GFTheme React SDK</p>
+        <h1>Reserva y compra en minutos</h1>
+        <p>Una experiencia mobile-first para clases, paquetes, cuenta y perfil con branding configurable.</p>
+        <div class="demo-hero__chips" aria-label="Caracteristicas">
+          <span>Mobile-first</span>
+          <span>Branding editable</span>
+          <span>Checkout ready</span>
+        </div>
       </section>
 
       <section id="calendar-demo"></section>
-      <section id="packages-demo"></section>
-      <section id="auth-demo"></section>
+      <div class="demo-grid">
+        <section id="packages-demo"></section>
+        <section id="auth-demo"></section>
+      </div>
       <section id="profile-demo"></section>
     </main>
 

--- a/packages/react-sdk/package-lock.json
+++ b/packages/react-sdk/package-lock.json
@@ -1,0 +1,2167 @@
+{
+  "name": "react-sdk",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "react-sdk",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@tanstack/react-query": "^5.100.6",
+        "zod": "^4.3.6",
+        "zustand": "^5.0.12"
+      },
+      "devDependencies": {
+        "@testing-library/react": "^16.3.2",
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
+        "@vitejs/plugin-react": "^6.0.1",
+        "jsdom": "^29.1.0",
+        "react": "^19.2.5",
+        "react-dom": "^19.2.5",
+        "typescript": "^6.0.3",
+        "vite": "^8.0.10",
+        "vitest": "^4.1.5"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
+      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
+      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.7",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.7.tgz",
+      "integrity": "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.100.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.6.tgz",
+      "integrity": "sha512-Os2CPUr98to98RYm+D4qGqGkiffn7MGSyl2547a4MljVkHE30AMJRqTiyCqBfMwzAx/I91vCkAxp5tHSla6Twg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.100.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.6.tgz",
+      "integrity": "sha512-uVSrps0PV16Cxmcn2rvL+dUhwTpTUtiRW347AEeYxMZXO2pZe9ja7E24PAMGoQ5u2g89DD8u4QhOviBk+RN8RA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.100.6"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.1.tgz",
+      "integrity": "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "1.0.0-rc.7"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.0.tgz",
+      "integrity": "sha512-YNUc7fB9QuvSSQWfrH0xF+TyABkxUwx8sswgIDaCrw4Hol8BghdZDkITtZheRJeMtzWlnTfsM3bBBusRvpO1wg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.5"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
+      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.127.0",
+        "@rolldown/pluginutils": "1.0.0-rc.17"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+      }
+    },
+    "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
+      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.29",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.29.tgz",
+      "integrity": "sha512-JIXCerhudr/N6OWLwLF1HVsTTUo7ry6qHa5eWZEkiMuxsIiAACL55tGLfqfHfoH7QaMQUW8fngD7u7TxWexYQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.29"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.29",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.29.tgz",
+      "integrity": "sha512-W99NuU7b1DcG3uJ3v9k9VztCH3WialNbBkBft5wCs8V8mexu0XQqaZEYb9l9RNNzK8+3EJ9PKWB0/RUtTQ/o+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
+      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.10",
+        "rolldown": "1.0.0-rc.17",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.12.tgz",
+      "integrity": "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/packages/react-sdk/package-lock.json
+++ b/packages/react-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "react-sdk",
-  "version": "1.0.0",
+  "name": "@gafa/theme-react-sdk",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "react-sdk",
-      "version": "1.0.0",
+      "name": "@gafa/theme-react-sdk",
+      "version": "0.1.0",
       "license": "ISC",
       "dependencies": {
         "@tanstack/react-query": "^5.100.6",
@@ -24,6 +24,10 @@
         "typescript": "^6.0.3",
         "vite": "^8.0.10",
         "vitest": "^4.1.5"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/@asamuzakjp/css-color": {

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@gafa/theme-react-sdk",
+  "version": "0.1.0",
+  "description": "Modern embeddable React SDK foundation for GFTheme.",
+  "type": "module",
+  "main": "./dist/gafa-theme-react-sdk.umd.cjs",
+  "module": "./dist/gafa-theme-react-sdk.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json && vite build",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run",
+    "dev": "vite --host 0.0.0.0"
+  },
+  "keywords": [
+    "gafa",
+    "sdk",
+    "react",
+    "booking",
+    "calendar"
+  ],
+  "author": "",
+  "license": "ISC",
+  "peerDependencies": {
+    "react": ">=18",
+    "react-dom": ">=18"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.100.6",
+    "zod": "^4.3.6",
+    "zustand": "^5.0.12"
+  },
+  "devDependencies": {
+    "@testing-library/react": "^16.3.2",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.1",
+    "jsdom": "^29.1.0",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
+    "typescript": "^6.0.3",
+    "vite": "^8.0.10",
+    "vitest": "^4.1.5"
+  }
+}

--- a/packages/react-sdk/src/main.tsx
+++ b/packages/react-sdk/src/main.tsx
@@ -1,0 +1,23 @@
+import { createGafaSdk } from "./sdk";
+
+const sdk = createGafaSdk(
+  {
+    apiBaseUrl: "https://example.gafa.fit",
+    companyId: 1,
+    publicClientId: "demo-client",
+    theme: {
+      preset: "boutique",
+      logoUrl: "/vite.svg",
+      colors: {
+        primary: "#111827",
+        accent: "#f97316",
+      },
+    },
+  },
+  { useMockClient: true },
+);
+
+sdk.mountCalendar("#calendar-demo");
+sdk.mountCatalog("#packages-demo", { type: "packages" });
+sdk.mountAuth("#auth-demo", { initialView: "login" });
+sdk.mountProfile("#profile-demo");

--- a/packages/react-sdk/src/main.tsx
+++ b/packages/react-sdk/src/main.tsx
@@ -3,7 +3,7 @@ import "./sdk/theme/theme.css";
 import "./sdk/widgets/widgets.css";
 
 document.body.style.margin = "0";
-document.body.style.background = "#f8fafc";
+document.body.style.background = "#f5efe8";
 
 const sdk = createGafaSdk(
   {
@@ -12,10 +12,15 @@ const sdk = createGafaSdk(
     publicClientId: "demo-client",
     theme: {
       preset: "boutique",
-      logoUrl: "/vite.svg",
       colors: {
-        primary: "#111827",
-        accent: "#f97316",
+        primary: "#16110f",
+        primaryText: "#fffaf4",
+        accent: "#ff6b2c",
+        background: "#f5efe8",
+        surface: "#fffaf4",
+        text: "#16110f",
+        mutedText: "#766b63",
+        border: "#eadfd4",
       },
     },
   },

--- a/packages/react-sdk/src/main.tsx
+++ b/packages/react-sdk/src/main.tsx
@@ -1,4 +1,9 @@
 import { createGafaSdk } from "./sdk";
+import "./sdk/theme/theme.css";
+import "./sdk/widgets/widgets.css";
+
+document.body.style.margin = "0";
+document.body.style.background = "#f8fafc";
 
 const sdk = createGafaSdk(
   {

--- a/packages/react-sdk/src/sdk/bootstrap/legacyBootstrap.tsx
+++ b/packages/react-sdk/src/sdk/bootstrap/legacyBootstrap.tsx
@@ -1,0 +1,167 @@
+import type { GafaSdk } from "../runtime";
+
+type LegacyWidgetName =
+  | "login"
+  | "register"
+  | "password-recovery"
+  | "profile-info"
+  | "login-register"
+  | "login-register-pages"
+  | "staff-list"
+  | "service-list"
+  | "combo-list"
+  | "membership-list"
+  | "meetings-calendar"
+  | "purchase-button"
+  | "fancy";
+
+const LEGACY_WIDGETS: LegacyWidgetName[] = [
+  "login",
+  "register",
+  "password-recovery",
+  "profile-info",
+  "login-register",
+  "login-register-pages",
+  "staff-list",
+  "service-list",
+  "combo-list",
+  "membership-list",
+  "meetings-calendar",
+  "purchase-button",
+  "fancy",
+];
+
+export type LegacyBootstrapResult = {
+  mounted: number;
+};
+
+export function bootstrapLegacyWidgets(runtime: GafaSdk, root: ParentNode = document): LegacyBootstrapResult {
+  let mounted = 0;
+
+  LEGACY_WIDGETS.forEach((widgetName) => {
+    root.querySelectorAll<HTMLElement>(`[data-gf-theme="${widgetName}"]`).forEach((element) => {
+      mountLegacyWidget(runtime, widgetName, element);
+      mounted += 1;
+    });
+  });
+
+  return { mounted };
+}
+
+function mountLegacyWidget(runtime: GafaSdk, widgetName: LegacyWidgetName, element: HTMLElement) {
+  switch (widgetName) {
+    case "meetings-calendar":
+      runtime.mountCalendar(element, {
+        limit: toNumber(element.getAttribute("data-gf-limit")),
+        visualization: readVisualization(element),
+        showDescription: element.getAttribute("data-bq-show-description") === "true",
+        filters: {
+          brand: element.hasAttribute("filter-bq-brand"),
+          location: element.hasAttribute("filter-bq-location"),
+          service: element.hasAttribute("filter-bq-service"),
+          staff: element.hasAttribute("filter-bq-staff"),
+          room: element.hasAttribute("filter-bq-room"),
+          brandId: toNumber(element.getAttribute("filter-bq-brand-default")),
+          locationId: toNumber(element.getAttribute("filter-bq-location-default")),
+          serviceId: toNumber(element.getAttribute("filter-bq-service-default")),
+          staffId: toNumber(element.getAttribute("filter-bq-staff-default")),
+        },
+      });
+      return;
+
+    case "combo-list":
+      runtime.mountCatalog(element, {
+        type: "packages",
+        filterByName: element.getAttribute("data-gf-filterbyname") || undefined,
+        filterByBrand: element.getAttribute("data-buq-brand") || undefined,
+      });
+      return;
+
+    case "membership-list":
+      runtime.mountCatalog(element, {
+        type: "memberships",
+        filterByName: element.getAttribute("data-gf-filterbyname") || undefined,
+        filterByBrand: element.getAttribute("data-buq-brand") || undefined,
+      });
+      return;
+
+    case "service-list":
+      runtime.mountCatalog(element, { type: "services" });
+      return;
+
+    case "staff-list":
+      runtime.mountCatalog(element, { type: "staff" });
+      return;
+
+    case "login":
+      runtime.mountAuth(element, { initialView: "login" });
+      return;
+
+    case "register":
+      runtime.mountAuth(element, { initialView: "register" });
+      return;
+
+    case "password-recovery":
+      runtime.mountAuth(element, { initialView: "password-recovery" });
+      return;
+
+    case "login-register":
+    case "login-register-pages":
+      runtime.mountAuth(element, {
+        initialView: readAuthInitialView(element),
+        baseUrl: element.getAttribute("data-gf-base-url") || undefined,
+      });
+      return;
+
+    case "profile-info":
+      runtime.mountProfile(element, {
+        combineWaitlist: element.getAttribute("data-bq-combine-waitlist") === "true",
+      });
+      return;
+
+    case "purchase-button":
+      runtime.mountPurchaseButton(element, {
+        comboId: element.getAttribute("data-bq-combo-id") || undefined,
+        membershipId: element.getAttribute("data-bq-membership-id") || undefined,
+        productId: element.getAttribute("data-bq-product-id") || undefined,
+        reservationId: element.getAttribute("data-bq-reservation-id") || undefined,
+        locationId: element.getAttribute("data-bq-location-id") || undefined,
+        defaultStoreTab: element.getAttribute("data-bq-default-store-tab") || undefined,
+        noLoading: element.getAttribute("data-bq-no-loading") === "true",
+      });
+      return;
+
+    case "fancy":
+      element.dataset.gafaCheckoutHost = "true";
+      return;
+  }
+}
+
+function readAuthInitialView(element: HTMLElement): "login" | "register" | "password-recovery" | "profile" {
+  const initial = element.getAttribute("data-gf-initial");
+
+  if (initial === "register" || initial === "password-recovery" || initial === "profile") {
+    return initial;
+  }
+
+  return "login";
+}
+
+function toNumber(value: string | null): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const parsed = Number(value);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+function readVisualization(element: HTMLElement) {
+  const visualization = element.getAttribute("data-bq-calendar-visualization");
+
+  if (visualization === "horizontal" || visualization === "vertical" || visualization === "agenda") {
+    return visualization;
+  }
+
+  return undefined;
+}

--- a/packages/react-sdk/src/sdk/client/gafaClient.ts
+++ b/packages/react-sdk/src/sdk/client/gafaClient.ts
@@ -21,12 +21,26 @@ export function createMockGafaClient(): GafaClient {
         slug: "roma-norte",
         brandSlug: "demo-studio",
       },
+      {
+        id: 2,
+        name: "Condesa",
+        slug: "condesa",
+        brandSlug: "demo-studio",
+      },
     ],
     listStaff: async () => [
       {
         id: 1,
         name: "Coach Demo",
+        lastname: "Rivera",
         bio: "Entrenador principal",
+        slug: "coach-demo",
+      },
+      {
+        id: 2,
+        name: "Coach Ana",
+        lastname: "Lopez",
+        slug: "coach-ana",
       },
     ],
     listServices: async () => [
@@ -34,6 +48,11 @@ export function createMockGafaClient(): GafaClient {
         id: 1,
         name: "Functional Training",
         durationMinutes: 50,
+      },
+      {
+        id: 2,
+        name: "Yoga Flow",
+        durationMinutes: 45,
       },
     ],
     listCombos: async () => [
@@ -83,6 +102,14 @@ function demoMeetings(): Meeting[] {
       staffName: "Coach Demo",
       serviceName: "Training",
       availability: "available",
+      available: 8,
+      capacity: 18,
+      isReserved: false,
+      location: {
+        id: 1,
+        name: "Roma Norte",
+        slug: "roma-norte",
+      },
     },
     {
       id: 2,
@@ -92,6 +119,14 @@ function demoMeetings(): Meeting[] {
       staffName: "Coach Ana",
       serviceName: "Wellness",
       availability: "waitlist",
+      available: 0,
+      capacity: 14,
+      isReserved: false,
+      location: {
+        id: 2,
+        name: "Condesa",
+        slug: "condesa",
+      },
     },
   ];
 }

--- a/packages/react-sdk/src/sdk/client/gafaClient.ts
+++ b/packages/react-sdk/src/sdk/client/gafaClient.ts
@@ -82,6 +82,7 @@ export function createMockGafaClient(): GafaClient {
     }),
     login: async () => ({ access_token: "demo-token" }),
     openCheckout: async () => undefined,
+    openReservationCheckout: async () => undefined,
   };
 }
 

--- a/packages/react-sdk/src/sdk/client/gafaClient.ts
+++ b/packages/react-sdk/src/sdk/client/gafaClient.ts
@@ -1,0 +1,97 @@
+import type { GafaClient, Meeting, UserProfile } from "./types";
+import type { GafaSdkConfig } from "../config";
+
+export function createGafaClient(_options: GafaSdkConfig): GafaClient {
+  return createMockGafaClient();
+}
+
+export function createMockGafaClient(): GafaClient {
+  return {
+    listBrands: async () => [
+      {
+        id: 1,
+        name: "Demo Studio",
+        slug: "demo-studio",
+      },
+    ],
+    listLocations: async () => [
+      {
+        id: 1,
+        name: "Roma Norte",
+        slug: "roma-norte",
+        brandSlug: "demo-studio",
+      },
+    ],
+    listStaff: async () => [
+      {
+        id: 1,
+        name: "Coach Demo",
+        bio: "Entrenador principal",
+      },
+    ],
+    listServices: async () => [
+      {
+        id: 1,
+        name: "Functional Training",
+        durationMinutes: 50,
+      },
+    ],
+    listCombos: async () => [
+      {
+        id: 1,
+        name: "10 clases",
+        description: "Paquete inicial para reservar en cualquier sede.",
+        priceLabel: "$1,200 MXN",
+        currency: "MXN",
+      },
+    ],
+    listMemberships: async () => [
+      {
+        id: 2,
+        name: "Mensual ilimitada",
+        description: "Membresia para clientes recurrentes.",
+        priceLabel: "$2,400 MXN",
+        currency: "MXN",
+      },
+    ],
+    listMeetings: async () => demoMeetings(),
+    getProfile: async (): Promise<UserProfile | null> => ({
+      id: 1,
+      name: "Usuario Demo",
+      email: "demo@gafa.fit",
+      creditsLabel: "5 creditos disponibles",
+    }),
+    login: async () => ({ access_token: "demo-token" }),
+    openCheckout: async () => undefined,
+  };
+}
+
+function demoMeetings(): Meeting[] {
+  const now = new Date();
+  const first = new Date(now);
+  first.setHours(8, 0, 0, 0);
+
+  const second = new Date(now);
+  second.setHours(18, 30, 0, 0);
+
+  return [
+    {
+      id: 1,
+      name: "Functional Training",
+      startsAt: first.toISOString(),
+      durationMinutes: 50,
+      staffName: "Coach Demo",
+      serviceName: "Training",
+      availability: "available",
+    },
+    {
+      id: 2,
+      name: "Mobility Flow",
+      startsAt: second.toISOString(),
+      durationMinutes: 45,
+      staffName: "Coach Ana",
+      serviceName: "Wellness",
+      availability: "waitlist",
+    },
+  ];
+}

--- a/packages/react-sdk/src/sdk/client/legacyGafaFitAdapter.ts
+++ b/packages/react-sdk/src/sdk/client/legacyGafaFitAdapter.ts
@@ -108,10 +108,12 @@ export function createLegacyGafaFitAdapter(config: GafaSdkConfig, legacySdk?: un
       end.setDate(end.getDate() + 14);
       const endDate = filters.to ?? end.toISOString().slice(0, 10);
 
-      return callbackToPromise<Meeting[]>((cb) => {
+      const meetings = await callbackToPromise<Meeting[]>((cb) => {
         const locationId = Number(filters.locationId);
         sdk.GetMeetingsInLocation?.(locationId, startDate, endDate, cb);
       });
+
+      return meetings.map(normalizeLegacyMeeting);
     },
     async getProfile() {
       if (!sdk.GetMe) return null;
@@ -123,5 +125,19 @@ export function createLegacyGafaFitAdapter(config: GafaSdkConfig, legacySdk?: un
     async openCheckout() {
       throw new Error("Checkout is not implemented in the legacy adapter foundation yet.");
     },
+  };
+}
+
+function normalizeLegacyMeeting(meeting: Meeting): Meeting {
+  const startsAt = meeting.startsAt ?? meeting.start ?? meeting.start_date;
+
+  return {
+    ...meeting,
+    startsAt,
+    serviceName: meeting.serviceName ?? meeting.service?.name,
+    staffName:
+      meeting.staffName ??
+      [meeting.staff?.name, meeting.staff?.lastname].filter(Boolean).join(" ") ??
+      undefined,
   };
 }

--- a/packages/react-sdk/src/sdk/client/legacyGafaFitAdapter.ts
+++ b/packages/react-sdk/src/sdk/client/legacyGafaFitAdapter.ts
@@ -28,6 +28,14 @@ type LegacyGafaFitSdk = {
     cb: LegacyCallback<Meeting[]>,
   ) => void;
   GetMe?: (cb: LegacyCallback<UserProfile | null>) => void;
+  GetCreateReservationForm?: (
+    brandSlug: string,
+    locationSlug: string | number | undefined,
+    userId: string | number | undefined,
+    targetSelector: string,
+    payload: Record<string, unknown>,
+    cb: LegacyCallback<unknown>,
+  ) => void;
 };
 
 declare global {
@@ -122,10 +130,52 @@ export function createLegacyGafaFitAdapter(config: GafaSdkConfig, legacySdk?: un
     async login() {
       throw new Error("Login is not implemented in the legacy adapter foundation yet.");
     },
-    async openCheckout() {
-      throw new Error("Checkout is not implemented in the legacy adapter foundation yet.");
+    async openCheckout(payload) {
+      if (!sdk.GetCreateReservationForm) {
+        throw new Error("GafaFitSDK.GetCreateReservationForm is not available.");
+      }
+
+      await callbackToPromise<unknown>((cb) => {
+        sdk.GetCreateReservationForm?.(
+          payload.brandSlug,
+          payload.locationId,
+          payload.userId,
+          payload.targetSelector ?? '[data-gf-theme="fancy"]',
+          payload.payload,
+          cb,
+        );
+      });
+    },
+    async openReservationCheckout(payload) {
+      if (!sdk.GetCreateReservationForm) {
+        throw new Error("GafaFitSDK.GetCreateReservationForm is not available.");
+      }
+
+      const userId = payload.userId ?? (await getLegacyUserId(sdk));
+
+      await callbackToPromise<unknown>((cb) => {
+        sdk.GetCreateReservationForm?.(
+          payload.brandSlug,
+          payload.locationSlug,
+          userId,
+          payload.targetSelector ?? '[data-gf-theme="fancy"]',
+          {
+            meetings_id: payload.meetingId,
+          },
+          cb,
+        );
+      });
     },
   };
+}
+
+async function getLegacyUserId(sdk: LegacyGafaFitSdk): Promise<string | number | undefined> {
+  if (!sdk.GetMe) {
+    return undefined;
+  }
+
+  const user = await callbackToPromise<UserProfile | null>((cb) => sdk.GetMe?.(cb));
+  return user?.id;
 }
 
 function normalizeLegacyMeeting(meeting: Meeting): Meeting {

--- a/packages/react-sdk/src/sdk/client/legacyGafaFitAdapter.ts
+++ b/packages/react-sdk/src/sdk/client/legacyGafaFitAdapter.ts
@@ -1,0 +1,127 @@
+import type {
+  GafaClient,
+  Brand,
+  CatalogItem,
+  Location,
+  Meeting,
+  Service,
+  StaffMember,
+  UserProfile,
+} from "./types";
+import type { GafaSdkConfig } from "../config";
+
+type LegacyCallback<T> = (error: unknown, result: T) => void;
+
+type LegacyGafaFitSdk = {
+  setUrl?: (url: string) => void;
+  setCompany?: (companyId: number) => void;
+  GetBrandList?: (options: Record<string, unknown>, cb: LegacyCallback<{ data: Brand[] }>) => void;
+  GetBrandLocations?: (brandSlug: string, options: Record<string, unknown>, cb: LegacyCallback<{ data: Location[] }>) => void;
+  GetBrandStaffList?: (brandSlug: string, options: Record<string, unknown>, cb: LegacyCallback<{ data: StaffMember[] }>) => void;
+  GetBrandServiceList?: (brandSlug: string, options: Record<string, unknown>, cb: LegacyCallback<{ data: Service[] }>) => void;
+  GetBrandCombolist?: (brandSlug: string, options: Record<string, unknown>, cb: LegacyCallback<{ data: CatalogItem[] }>) => void;
+  GetBrandMembershipList?: (brandSlug: string, options: Record<string, unknown>, cb: LegacyCallback<{ data: CatalogItem[] }>) => void;
+  GetMeetingsInLocation?: (
+    locationId: number,
+    startDate: string,
+    endDate: string,
+    cb: LegacyCallback<Meeting[]>,
+  ) => void;
+  GetMe?: (cb: LegacyCallback<UserProfile | null>) => void;
+};
+
+declare global {
+  interface Window {
+    GafaFitSDK?: LegacyGafaFitSdk;
+  }
+}
+
+function requireLegacySdk(): LegacyGafaFitSdk {
+  if (!window.GafaFitSDK) {
+    throw new Error("window.GafaFitSDK is required when using the legacy adapter.");
+  }
+
+  return window.GafaFitSDK;
+}
+
+function callbackToPromise<T>(invoke: (cb: LegacyCallback<T>) => void): Promise<T> {
+  return new Promise((resolve, reject) => {
+    invoke((error, result) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve(result);
+    });
+  });
+}
+
+export function createLegacyGafaFitAdapter(config: GafaSdkConfig, legacySdk?: unknown): GafaClient {
+  const sdk = (legacySdk as LegacyGafaFitSdk | undefined) ?? requireLegacySdk();
+
+  sdk.setUrl?.(config.apiBaseUrl);
+  sdk.setCompany?.(config.companyId);
+
+  return {
+    async listBrands() {
+      const result = await callbackToPromise<{ data: Brand[] }>((cb) => sdk.GetBrandList?.({}, cb));
+      return result.data;
+    },
+    async listLocations(brandSlug?: string) {
+      if (!brandSlug) return [];
+      const result = await callbackToPromise<{ data: Location[] }>((cb) =>
+        sdk.GetBrandLocations?.(brandSlug, { per_page: 1000 }, cb),
+      );
+      return result.data;
+    },
+    async listStaff(brandSlug?: string) {
+      if (!brandSlug) return [];
+      const result = await callbackToPromise<{ data: StaffMember[] }>((cb) =>
+        sdk.GetBrandStaffList?.(brandSlug, { per_page: 1000 }, cb),
+      );
+      return result.data;
+    },
+    async listServices(brandSlug?: string) {
+      if (!brandSlug) return [];
+      const result = await callbackToPromise<{ data: Service[] }>((cb) =>
+        sdk.GetBrandServiceList?.(brandSlug, { per_page: 1000 }, cb),
+      );
+      return result.data;
+    },
+    async listCombos(brandSlug: string) {
+      const result = await callbackToPromise<{ data: CatalogItem[] }>((cb) =>
+        sdk.GetBrandCombolist?.(brandSlug, { per_page: 10000, only_actives: true, propagate: true }, cb),
+      );
+      return result.data.map((item) => ({ ...item, type: "combo" as const }));
+    },
+    async listMemberships(brandSlug: string) {
+      const result = await callbackToPromise<{ data: CatalogItem[] }>((cb) =>
+        sdk.GetBrandMembershipList?.(brandSlug, { per_page: 10000, only_actives: true, propagate: true }, cb),
+      );
+      return result.data.map((item) => ({ ...item, type: "membership" as const }));
+    },
+    async listMeetings(filters = {}) {
+      if (!filters.locationId || !sdk.GetMeetingsInLocation) return [];
+      const startDate = filters.from ?? new Date().toISOString().slice(0, 10);
+      const end = new Date(startDate);
+      end.setDate(end.getDate() + 14);
+      const endDate = filters.to ?? end.toISOString().slice(0, 10);
+
+      return callbackToPromise<Meeting[]>((cb) => {
+        const locationId = Number(filters.locationId);
+        sdk.GetMeetingsInLocation?.(locationId, startDate, endDate, cb);
+      });
+    },
+    async getProfile() {
+      if (!sdk.GetMe) return null;
+      return callbackToPromise<UserProfile | null>((cb) => sdk.GetMe?.(cb));
+    },
+    async login() {
+      throw new Error("Login is not implemented in the legacy adapter foundation yet.");
+    },
+    async openCheckout() {
+      throw new Error("Checkout is not implemented in the legacy adapter foundation yet.");
+    },
+  };
+}

--- a/packages/react-sdk/src/sdk/client/types.ts
+++ b/packages/react-sdk/src/sdk/client/types.ts
@@ -9,6 +9,7 @@ export type Location = {
   name: string;
   slug: string;
   brandSlug?: string;
+  brand?: Brand;
 };
 
 export type Service = {
@@ -21,6 +22,7 @@ export type Service = {
 export type StaffMember = {
   id: number;
   name: string;
+  lastname?: string;
   bio?: string;
   photoUrl?: string;
 };
@@ -29,14 +31,24 @@ export type Meeting = {
   id: number;
   name: string;
   startsAt: string;
+  start?: string;
+  start_date?: string;
+  startTime?: string;
+  timeLabel?: string;
   endsAt?: string;
   durationMinutes?: number;
   description?: string;
   service?: Service;
+  serviceId?: string | number;
   serviceName?: string;
   staff?: StaffMember;
+  staffId?: string | number;
   staffName?: string;
   location?: Location;
+  available?: number;
+  capacity?: number;
+  isReserved?: boolean;
+  passed?: boolean;
   availability?:
     | "available"
     | "waitlist"

--- a/packages/react-sdk/src/sdk/client/types.ts
+++ b/packages/react-sdk/src/sdk/client/types.ts
@@ -30,6 +30,7 @@ export type StaffMember = {
 export type Meeting = {
   id: number;
   name: string;
+  brandSlug?: string;
   startsAt: string;
   start?: string;
   start_date?: string;
@@ -45,6 +46,7 @@ export type Meeting = {
   staffId?: string | number;
   staffName?: string;
   location?: Location;
+  locationSlug?: string;
   available?: number;
   capacity?: number;
   isReserved?: boolean;
@@ -102,6 +104,14 @@ export type CheckoutPayload = {
   payload: Record<string, unknown>;
 };
 
+export type ReservationCheckoutPayload = {
+  meetingId: string | number;
+  brandSlug: string;
+  locationSlug: string;
+  userId?: string | number;
+  targetSelector?: string;
+};
+
 export type MeetingFilters = {
   brandId?: string | number;
   locationId?: string | number;
@@ -125,4 +135,5 @@ export type GafaClient = {
   getProfile(): Promise<UserProfile | null>;
   login(credentials: AuthCredentials): Promise<{ access_token: string }>;
   openCheckout(payload: CheckoutPayload): Promise<void>;
+  openReservationCheckout(payload: ReservationCheckoutPayload): Promise<void>;
 };

--- a/packages/react-sdk/src/sdk/client/types.ts
+++ b/packages/react-sdk/src/sdk/client/types.ts
@@ -1,0 +1,116 @@
+export type Brand = {
+  id: number;
+  name: string;
+  slug: string;
+};
+
+export type Location = {
+  id: number;
+  name: string;
+  slug: string;
+  brandSlug?: string;
+};
+
+export type Service = {
+  id: number;
+  name: string;
+  description?: string;
+  durationMinutes?: number;
+};
+
+export type StaffMember = {
+  id: number;
+  name: string;
+  bio?: string;
+  photoUrl?: string;
+};
+
+export type Meeting = {
+  id: number;
+  name: string;
+  startsAt: string;
+  endsAt?: string;
+  durationMinutes?: number;
+  description?: string;
+  service?: Service;
+  serviceName?: string;
+  staff?: StaffMember;
+  staffName?: string;
+  location?: Location;
+  availability?:
+    | "available"
+    | "waitlist"
+    | "sold-out"
+    | {
+    capacity?: number;
+    reserved?: number;
+    waitlist?: number;
+      };
+};
+
+export type GafaMeeting = Meeting;
+
+export type CatalogItem = {
+  id: number;
+  name: string;
+  description?: string;
+  price?: number;
+  priceLabel?: string;
+  currency?: string;
+  ctaLabel?: string;
+  type?: "combo" | "membership" | "product" | "service" | "staff";
+};
+
+export type UserProfile = {
+  id: number;
+  name: string;
+  email: string;
+  creditsLabel?: string;
+};
+
+export type GafaUser = UserProfile;
+
+export type GafaClientOptions = {
+  apiBaseUrl: string;
+  companyId: number;
+  publicClientId?: string | number;
+  clientSecret?: string;
+};
+
+export type AuthCredentials = {
+  email: string;
+  password: string;
+};
+
+export type CheckoutPayload = {
+  brandSlug: string;
+  locationId?: string | number;
+  userId?: string | number;
+  targetSelector?: string;
+  payload: Record<string, unknown>;
+};
+
+export type MeetingFilters = {
+  brandId?: string | number;
+  locationId?: string | number;
+  serviceId?: string | number;
+  staffId?: string | number;
+  roomId?: string | number;
+  from?: string;
+  to?: string;
+  startDate?: string;
+  endDate?: string;
+};
+
+export type GafaClient = {
+  listBrands(): Promise<Brand[]>;
+  listLocations(brandSlug?: string): Promise<Location[]>;
+  listServices(brandSlug?: string): Promise<Service[]>;
+  listStaff(brandSlug?: string): Promise<StaffMember[]>;
+  listMeetings(filters?: MeetingFilters): Promise<Meeting[]>;
+  listCombos(brandSlug: string): Promise<CatalogItem[]>;
+  listMemberships(brandSlug: string): Promise<CatalogItem[]>;
+  getProfile(): Promise<UserProfile | null>;
+  login(credentials: AuthCredentials): Promise<{ access_token: string }>;
+  openCheckout(payload: CheckoutPayload): Promise<void>;
+};

--- a/packages/react-sdk/src/sdk/config.ts
+++ b/packages/react-sdk/src/sdk/config.ts
@@ -1,0 +1,89 @@
+import { z } from "zod";
+import type { GafaBrandTheme } from "./theme/theme";
+
+const legacyThemeSchema = z
+  .object({
+    preset: z.string().optional(),
+    logoUrl: z.string().optional(),
+    colors: z.record(z.string(), z.string()).optional(),
+    typography: z
+      .object({
+        fontFamily: z.string().optional(),
+        headingFontFamily: z.string().optional(),
+      })
+      .optional(),
+    radius: z.record(z.string(), z.string()).optional(),
+    assets: z.record(z.string(), z.string()).optional(),
+  })
+  .passthrough()
+  .optional();
+
+export const sdkConfigSchema = z
+  .object({
+    apiBaseUrl: z.string().min(1),
+    companyId: z.union([z.string(), z.number()]).transform(Number),
+    publicClientId: z.union([z.string(), z.number()]).optional(),
+    brandId: z.union([z.string(), z.number()]).transform(Number).optional(),
+    tokenMovil: z.string().nullable().optional(),
+    captchaPublicKey: z.string().optional(),
+    language: z.enum(["es", "en"]).default("es"),
+    theme: legacyThemeSchema,
+  })
+  .passthrough();
+
+export type GafaSdkConfig = z.infer<typeof sdkConfigSchema> & {
+  theme?: GafaBrandTheme;
+};
+
+const legacyOptionsSchema = z
+  .object({
+    GAFA_FIT_URL: z.string().min(1),
+    COMPANY_ID: z.union([z.string(), z.number()]),
+    API_CLIENT: z.union([z.string(), z.number()]).optional(),
+    BRAND_ID: z.union([z.string(), z.number()]).optional(),
+    TOKENMOVIL: z.string().nullable().optional(),
+    CAPTCHA_PUBLIC_KEY: z.string().optional(),
+    THEME: legacyThemeSchema,
+  })
+  .passthrough();
+
+export type GafaSdkConfigInput = z.input<typeof sdkConfigSchema>;
+export type LegacyGfOptions = z.input<typeof legacyOptionsSchema>;
+
+export function parseGafaSdkConfig(input: unknown): GafaSdkConfig {
+  return sdkConfigSchema.parse(input);
+}
+
+export const parseSdkConfig = parseGafaSdkConfig;
+
+export function legacyOptionsToConfig(input: unknown): GafaSdkConfig {
+  const legacyOptions = legacyOptionsSchema.parse(input);
+
+  return parseGafaSdkConfig({
+    apiBaseUrl: legacyOptions.GAFA_FIT_URL,
+    companyId: legacyOptions.COMPANY_ID,
+    publicClientId: legacyOptions.API_CLIENT,
+    brandId: legacyOptions.BRAND_ID,
+    tokenMovil: legacyOptions.TOKENMOVIL,
+    captchaPublicKey: legacyOptions.CAPTCHA_PUBLIC_KEY,
+    theme: legacyOptions.THEME,
+  });
+}
+
+export function readLegacyOptionsFromDom(documentRef: Document = document): GafaSdkConfig {
+  const optionsElement = documentRef.querySelector("[data-gf-options]");
+
+  if (!optionsElement) {
+    throw new Error("GFTheme options were not found. Expected a [data-gf-options] JSON script.");
+  }
+
+  const json = optionsElement.textContent?.trim();
+
+  if (!json) {
+    throw new Error("GFTheme options are empty.");
+  }
+
+  return legacyOptionsToConfig(JSON.parse(json));
+}
+
+export const parseLegacyOptions = legacyOptionsToConfig;

--- a/packages/react-sdk/src/sdk/index.ts
+++ b/packages/react-sdk/src/sdk/index.ts
@@ -1,0 +1,8 @@
+export { createGafaSdk } from "./runtime";
+export type { GafaSdk, MountedWidget } from "./runtime";
+export { legacyOptionsToConfig, parseSdkConfig, readLegacyOptionsFromDom } from "./config";
+export type { GafaSdkConfig, GafaSdkConfigInput } from "./config";
+export { bootstrapLegacyWidgets } from "./bootstrap/legacyBootstrap";
+export type { LegacyBootstrapResult } from "./bootstrap/legacyBootstrap";
+export type { GafaBrandTheme } from "./theme/theme";
+export type { GafaClient } from "./client/types";

--- a/packages/react-sdk/src/sdk/runtime.tsx
+++ b/packages/react-sdk/src/sdk/runtime.tsx
@@ -1,0 +1,128 @@
+import React, { type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { parseSdkConfig, type GafaSdkConfigInput, type GafaSdkConfig } from "./config";
+import { createGafaClient } from "./client/gafaClient";
+import type { GafaClient } from "./client/types";
+import { createLegacyGafaFitAdapter } from "./client/legacyGafaFitAdapter";
+import { ThemeProvider } from "./theme/theme";
+import { AuthWidget, type AuthWidgetProps } from "./widgets/AuthWidget";
+import { CalendarWidget, type CalendarWidgetProps } from "./widgets/CalendarWidget";
+import { CatalogWidget, type CatalogWidgetProps } from "./widgets/CatalogWidget";
+import { ProfileWidget, type ProfileWidgetProps } from "./widgets/ProfileWidget";
+import { PurchaseButtonWidget, type PurchaseButtonWidgetProps } from "./widgets/PurchaseButtonWidget";
+import "./theme/theme.css";
+import "./widgets/widgets.css";
+
+export type GafaSdk = {
+  config: GafaSdkConfig;
+  client: GafaClient;
+  mountCalendar(target: string | Element, props?: CalendarWidgetProps): MountedWidget;
+  mountAuth(target: string | Element, props?: AuthWidgetProps): MountedWidget;
+  mountCatalog(target: string | Element, props?: CatalogWidgetProps): MountedWidget;
+  mountProfile(target: string | Element, props?: ProfileWidgetProps): MountedWidget;
+  mountPurchaseButton(target: Element, props?: PurchaseButtonWidgetProps): MountedWidget;
+  unmountAll(): void;
+};
+
+export type MountedWidget = {
+  root: Root;
+  element: Element;
+  unmount(): void;
+};
+
+type RuntimeOptions = {
+  client?: GafaClient;
+  useMockClient?: boolean;
+};
+
+export function createGafaSdk(input: GafaSdkConfigInput, options: RuntimeOptions = {}): GafaSdk {
+  const config = parseSdkConfig(input);
+  const client = options.client ?? createClient(config, options);
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 60_000,
+        retry: 1
+      }
+    }
+  });
+  const mounts = new Set<MountedWidget>();
+
+  function mount(target: string | Element, node: ReactNode): MountedWidget {
+    const element = resolveTarget(target);
+    const root = createRoot(element);
+    const mounted: MountedWidget = {
+      root,
+      element,
+      unmount() {
+        root.unmount();
+        mounts.delete(mounted);
+      }
+    };
+
+    root.render(
+      <React.StrictMode>
+        <QueryClientProvider client={queryClient}>
+          <ThemeProvider theme={config.theme}>
+            {node}
+          </ThemeProvider>
+        </QueryClientProvider>
+      </React.StrictMode>
+    );
+
+    mounts.add(mounted);
+    return mounted;
+  }
+
+  return {
+    config,
+    client,
+    mountCalendar(target, props = {}) {
+      return mount(target, <CalendarWidget client={client} {...props} />);
+    },
+    mountAuth(target, props = {}) {
+      return mount(target, <AuthWidget client={client} {...props} />);
+    },
+    mountCatalog(target, props = {}) {
+      return mount(target, <CatalogWidget client={client} {...props} />);
+    },
+    mountProfile(target, props = {}) {
+      return mount(target, <ProfileWidget client={client} {...props} />);
+    },
+    mountPurchaseButton(target, props = {}) {
+      return mount(target, <PurchaseButtonWidget client={client} hostElement={target} {...props} />);
+    },
+    unmountAll() {
+      Array.from(mounts).forEach((mounted) => mounted.unmount());
+      queryClient.clear();
+    }
+  };
+}
+
+function createClient(config: GafaSdkConfig, options: RuntimeOptions): GafaClient {
+  if (options.useMockClient) {
+    return createGafaClient(config);
+  }
+
+  if (typeof window !== "undefined" && window.GafaFitSDK) {
+    return createLegacyGafaFitAdapter(config, window.GafaFitSDK);
+  }
+
+  return createGafaClient(config);
+}
+
+function resolveTarget(target: string | Element): Element {
+  if (typeof target !== "string") {
+    return target;
+  }
+
+  const element = document.querySelector(target);
+
+  if (!element) {
+    throw new Error(`Gafa SDK target not found: ${target}`);
+  }
+
+  return element;
+}
+

--- a/packages/react-sdk/src/sdk/theme/theme.css
+++ b/packages/react-sdk/src/sdk/theme/theme.css
@@ -15,9 +15,16 @@
   --gafa-radius-md: 14px;
   --gafa-radius-lg: 22px;
   --gafa-radius-pill: 999px;
-  --gafa-shadow-card: 0 18px 45px rgba(15, 23, 42, 0.08);
+  --gafa-space-1: 0.35rem;
+  --gafa-space-2: 0.65rem;
+  --gafa-space-3: 1rem;
+  --gafa-space-4: 1.35rem;
+  --gafa-space-5: 1.75rem;
+  --gafa-space-6: 2.25rem;
+  --gafa-shadow-card: 0 20px 55px rgba(19, 15, 35, 0.12);
+  --gafa-shadow-soft: 0 10px 28px rgba(19, 15, 35, 0.08);
 
-  background: var(--gafa-color-background);
+  background: transparent;
   border-radius: var(--gafa-radius-lg);
   color: var(--gafa-color-text);
   font-family: var(--gafa-font-family);
@@ -26,4 +33,10 @@
 
 .gafa-sdk * {
   box-sizing: border-box;
+}
+
+.gafa-sdk button,
+.gafa-sdk input,
+.gafa-sdk select {
+  font-family: inherit;
 }

--- a/packages/react-sdk/src/sdk/theme/theme.css
+++ b/packages/react-sdk/src/sdk/theme/theme.css
@@ -1,0 +1,29 @@
+.gafa-sdk {
+  --gafa-color-primary: #111827;
+  --gafa-color-primary-text: #ffffff;
+  --gafa-color-accent: #f97316;
+  --gafa-color-background: #f8fafc;
+  --gafa-color-surface: #ffffff;
+  --gafa-color-text: #111827;
+  --gafa-color-muted-text: #64748b;
+  --gafa-color-border: #e2e8f0;
+  --gafa-color-success: #16a34a;
+  --gafa-color-danger: #dc2626;
+  --gafa-font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --gafa-heading-font-family: var(--gafa-font-family);
+  --gafa-radius-sm: 8px;
+  --gafa-radius-md: 14px;
+  --gafa-radius-lg: 22px;
+  --gafa-radius-pill: 999px;
+  --gafa-shadow-card: 0 18px 45px rgba(15, 23, 42, 0.08);
+
+  background: var(--gafa-color-background);
+  border-radius: var(--gafa-radius-lg);
+  color: var(--gafa-color-text);
+  font-family: var(--gafa-font-family);
+  line-height: 1.5;
+}
+
+.gafa-sdk * {
+  box-sizing: border-box;
+}

--- a/packages/react-sdk/src/sdk/theme/theme.tsx
+++ b/packages/react-sdk/src/sdk/theme/theme.tsx
@@ -1,0 +1,183 @@
+export type GafaThemeColors = {
+  primary: string;
+  primaryText: string;
+  accent: string;
+  background: string;
+  surface: string;
+  text: string;
+  mutedText: string;
+  border: string;
+  success: string;
+  danger: string;
+};
+
+type ResolvedGafaTheme = {
+  preset: string;
+  logoUrl: string;
+  colors: GafaThemeColors;
+  typography: {
+    fontFamily: string;
+    headingFontFamily: string;
+  };
+  radius: GafaThemeRadius;
+  assets: {
+    heroBackgroundUrl?: string;
+    loginBackgroundUrl?: string;
+  };
+};
+
+export type GafaThemeRadius = {
+  sm: string;
+  md: string;
+  lg: string;
+  pill: string;
+};
+
+export type GafaBrandTheme = {
+  preset?: string;
+  logoUrl?: string;
+  colors?: Partial<GafaThemeColors>;
+  typography?: {
+    fontFamily?: string;
+    headingFontFamily?: string;
+  };
+  radius?: Partial<GafaThemeRadius>;
+  assets?: {
+    heroBackgroundUrl?: string;
+    loginBackgroundUrl?: string;
+  };
+};
+
+const defaultColors: GafaThemeColors = {
+  primary: "#111827",
+  primaryText: "#ffffff",
+  accent: "#f97316",
+  background: "#f8fafc",
+  surface: "#ffffff",
+  text: "#0f172a",
+  mutedText: "#64748b",
+  border: "#e2e8f0",
+  success: "#16a34a",
+  danger: "#dc2626",
+};
+
+const defaultRadius: GafaThemeRadius = {
+  sm: "8px",
+  md: "14px",
+  lg: "22px",
+  pill: "999px",
+};
+
+const presets: Record<string, GafaBrandTheme> = {
+  default: {},
+  boutique: {
+    colors: {
+      primary: "#18181b",
+      accent: "#ec4899",
+      background: "#fff7fb",
+      surface: "#ffffff",
+    },
+    radius: {
+      md: "18px",
+      lg: "28px",
+    },
+  },
+  "fitness-dark": {
+    colors: {
+      primary: "#f97316",
+      primaryText: "#111827",
+      accent: "#22c55e",
+      background: "#09090b",
+      surface: "#18181b",
+      text: "#fafafa",
+      mutedText: "#a1a1aa",
+      border: "#27272a",
+    },
+  },
+  "wellness-light": {
+    colors: {
+      primary: "#0f766e",
+      accent: "#14b8a6",
+      background: "#f0fdfa",
+      surface: "#ffffff",
+    },
+  },
+};
+
+export function resolveTheme(theme?: GafaBrandTheme): ResolvedGafaTheme {
+  const preset = presets[theme?.preset ?? "default"] ?? presets.default;
+
+  return {
+    preset: theme?.preset ?? "default",
+    logoUrl: theme?.logoUrl ?? preset.logoUrl ?? "",
+    colors: {
+      ...defaultColors,
+      ...preset.colors,
+      ...theme?.colors,
+    },
+    typography: {
+      fontFamily:
+        theme?.typography?.fontFamily ??
+        preset.typography?.fontFamily ??
+        "Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+      headingFontFamily:
+        theme?.typography?.headingFontFamily ??
+        preset.typography?.headingFontFamily ??
+        theme?.typography?.fontFamily ??
+        preset.typography?.fontFamily ??
+        "Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+    },
+    radius: {
+      ...defaultRadius,
+      ...preset.radius,
+      ...theme?.radius,
+    },
+    assets: {
+      ...preset.assets,
+      ...theme?.assets,
+    },
+  };
+}
+
+export function themeToCssVariables(theme?: GafaBrandTheme): Record<string, string> {
+  const resolved = resolveTheme(theme);
+
+  return {
+    "--gafa-color-primary": resolved.colors.primary,
+    "--gafa-color-primary-text": resolved.colors.primaryText,
+    "--gafa-color-accent": resolved.colors.accent,
+    "--gafa-color-background": resolved.colors.background,
+    "--gafa-color-surface": resolved.colors.surface,
+    "--gafa-color-text": resolved.colors.text,
+    "--gafa-color-muted-text": resolved.colors.mutedText,
+    "--gafa-color-border": resolved.colors.border,
+    "--gafa-color-success": resolved.colors.success,
+    "--gafa-color-danger": resolved.colors.danger,
+    "--gafa-font-body": resolved.typography.fontFamily,
+    "--gafa-font-heading": resolved.typography.headingFontFamily,
+    "--gafa-radius-sm": resolved.radius.sm,
+    "--gafa-radius-md": resolved.radius.md,
+    "--gafa-radius-lg": resolved.radius.lg,
+    "--gafa-radius-pill": resolved.radius.pill,
+    "--gafa-asset-hero-background": resolved.assets.heroBackgroundUrl
+      ? `url("${resolved.assets.heroBackgroundUrl}")`
+      : "none",
+    "--gafa-asset-login-background": resolved.assets.loginBackgroundUrl
+      ? `url("${resolved.assets.loginBackgroundUrl}")`
+      : "none",
+  };
+}
+
+export function ThemeProvider({
+  children,
+  theme,
+}: {
+  children: React.ReactNode;
+  theme?: GafaBrandTheme;
+}) {
+  return (
+    <div className="gafa-sdk" style={themeToCssVariables(theme) as React.CSSProperties}>
+      {children}
+    </div>
+  );
+}

--- a/packages/react-sdk/src/sdk/vite-env.d.ts
+++ b/packages/react-sdk/src/sdk/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/packages/react-sdk/src/sdk/widgets/AuthWidget.tsx
+++ b/packages/react-sdk/src/sdk/widgets/AuthWidget.tsx
@@ -36,22 +36,22 @@ export function AuthWidget({ initialView = "login", baseUrl }: AuthWidgetProps) 
 
       <form className="gafa-sdk-form">
         {formView === "register" ? (
-          <label>
-            Nombre
+          <label className="gafa-sdk-field">
+            <span>Nombre</span>
             <input placeholder="Tu nombre" />
           </label>
         ) : null}
-        <label>
-          Email
+        <label className="gafa-sdk-field">
+          <span>Email</span>
           <input type="email" placeholder="tu@email.com" />
         </label>
         {formView !== "password-recovery" ? (
-          <label>
-            Password
+          <label className="gafa-sdk-field">
+            <span>Password</span>
             <input type="password" placeholder="••••••••" />
           </label>
         ) : null}
-        <button className="gafa-sdk-primary-button" type="button">
+        <button className="gafa-sdk-button" type="button">
           {formView === "register" ? "Crear cuenta" : formView === "password-recovery" ? "Enviar instrucciones" : "Entrar"}
         </button>
       </form>

--- a/packages/react-sdk/src/sdk/widgets/AuthWidget.tsx
+++ b/packages/react-sdk/src/sdk/widgets/AuthWidget.tsx
@@ -55,6 +55,7 @@ export function AuthWidget({ initialView = "login", baseUrl }: AuthWidgetProps) 
           {formView === "register" ? "Crear cuenta" : formView === "password-recovery" ? "Enviar instrucciones" : "Entrar"}
         </button>
       </form>
+      <p className="gafa-auth-note">Seguro, rapido y listo para conectarse a tu API de usuarios.</p>
       {baseUrl ? <p className="gafa-muted">Base URL configurada: {baseUrl}</p> : null}
     </WidgetShell>
   );

--- a/packages/react-sdk/src/sdk/widgets/AuthWidget.tsx
+++ b/packages/react-sdk/src/sdk/widgets/AuthWidget.tsx
@@ -1,0 +1,61 @@
+import { useState } from "react";
+import type { GafaClient } from "../client/types";
+import { WidgetShell } from "./WidgetShell";
+
+export type AuthView = "login" | "register" | "password-recovery" | "profile";
+
+export type AuthWidgetProps = {
+  client?: GafaClient;
+  initialView?: AuthView;
+  baseUrl?: string;
+};
+
+export function AuthWidget({ initialView = "login", baseUrl }: AuthWidgetProps) {
+  const [view, setView] = useState(initialView);
+  const formView = view === "profile" ? "login" : view;
+
+  return (
+    <WidgetShell
+      eyebrow="Cuenta"
+      title={
+        formView === "register" ? "Crea tu cuenta" : formView === "password-recovery" ? "Recupera tu acceso" : "Bienvenido"
+      }
+      description="Flujo base para login, registro y recuperacion de password."
+    >
+      <div className="gafa-sdk-auth-tabs" role="tablist" aria-label="Opciones de cuenta">
+        <button type="button" aria-pressed={formView === "login"} onClick={() => setView("login")}>
+          Login
+        </button>
+        <button type="button" aria-pressed={formView === "register"} onClick={() => setView("register")}>
+          Registro
+        </button>
+        <button type="button" aria-pressed={formView === "password-recovery"} onClick={() => setView("password-recovery")}>
+          Password
+        </button>
+      </div>
+
+      <form className="gafa-sdk-form">
+        {formView === "register" ? (
+          <label>
+            Nombre
+            <input placeholder="Tu nombre" />
+          </label>
+        ) : null}
+        <label>
+          Email
+          <input type="email" placeholder="tu@email.com" />
+        </label>
+        {formView !== "password-recovery" ? (
+          <label>
+            Password
+            <input type="password" placeholder="••••••••" />
+          </label>
+        ) : null}
+        <button className="gafa-sdk-primary-button" type="button">
+          {formView === "register" ? "Crear cuenta" : formView === "password-recovery" ? "Enviar instrucciones" : "Entrar"}
+        </button>
+      </form>
+      {baseUrl ? <p className="gafa-muted">Base URL configurada: {baseUrl}</p> : null}
+    </WidgetShell>
+  );
+}

--- a/packages/react-sdk/src/sdk/widgets/CalendarWidget.tsx
+++ b/packages/react-sdk/src/sdk/widgets/CalendarWidget.tsx
@@ -136,9 +136,9 @@ export function CalendarWidget({
         staff={staffQuery.data ?? []}
       />
 
-      {isLoading ? <p className="gafa-sdk__state">Cargando calendario...</p> : null}
+      {isLoading ? <p className="gafa-sdk-state">Cargando calendario...</p> : null}
       {hasError ? (
-        <p className="gafa-sdk__state gafa-sdk__state--error">No pudimos cargar el calendario.</p>
+        <p className="gafa-sdk-state gafa-sdk-state--error">No pudimos cargar el calendario.</p>
       ) : null}
       <div className="gafa-calendar" data-visualization={visualization}>
         {!isLoading && Object.entries(meetingsByDay).length === 0 ? (
@@ -153,7 +153,7 @@ export function CalendarWidget({
               <div className="gafa-meeting-list">
                 {meetings.map((meeting) => (
                   <article className="gafa-meeting-card" key={meeting.id}>
-                    <div className="gafa-meeting-card__body">
+                    <div className="gafa-meeting-card__main">
                       <span className="gafa-meeting-time">{formatTime(getMeetingStart(meeting))}</span>
                       <h4>{meeting.name}</h4>
                       <p>{meeting.service?.name ?? meeting.serviceName ?? meeting.staff?.name ?? "Servicio"}</p>

--- a/packages/react-sdk/src/sdk/widgets/CalendarWidget.tsx
+++ b/packages/react-sdk/src/sdk/widgets/CalendarWidget.tsx
@@ -43,6 +43,7 @@ export function CalendarWidget({
 }: CalendarWidgetProps) {
   const [selectedFilters, setSelectedFilters] = useState<CalendarFiltersState>({});
   const [reservation, setReservation] = useState<ReservationState>({});
+  const [selectedMeeting, setSelectedMeeting] = useState<Meeting | null>(null);
   const range = useMemo(() => defaultMeetingRange(), []);
 
   const brandsQuery = useQuery({
@@ -141,7 +142,7 @@ export function CalendarWidget({
       });
 
       setReservation({
-        success: "Abrimos el flujo de reserva.",
+        success: "Listo. En una integracion real aqui se abre el checkout de reserva.",
       });
     } catch (error) {
       setReservation({
@@ -206,17 +207,11 @@ export function CalendarWidget({
                       <AvailabilityPill meeting={meeting} />
                       <button
                         className="gafa-sdk-button"
-                        disabled={isSoldOut(meeting) || reservation.meetingId === meeting.id}
+                        disabled={isSoldOut(meeting)}
                         type="button"
-                        onClick={() => handleReserve(meeting)}
+                        onClick={() => setSelectedMeeting(meeting)}
                       >
-                        {reservation.meetingId === meeting.id
-                          ? "Abriendo..."
-                          : meeting.isReserved
-                            ? "Reservado"
-                            : isSoldOut(meeting)
-                              ? "Sin lugares"
-                              : "Reservar"}
+                        {meeting.isReserved ? "Reservado" : isSoldOut(meeting) ? "Sin lugares" : "Reservar"}
                       </button>
                     </div>
                   </article>
@@ -226,7 +221,97 @@ export function CalendarWidget({
           ))
         )}
       </div>
+
+      {selectedMeeting ? (
+        <ReservationPreviewModal
+          isBusy={reservation.meetingId === selectedMeeting.id}
+          meeting={selectedMeeting}
+          message={reservation.meetingId === selectedMeeting.id ? undefined : reservation.success}
+          onClose={() => {
+            setSelectedMeeting(null);
+            setReservation({});
+          }}
+          onContinue={() => handleReserve(selectedMeeting)}
+        />
+      ) : null}
     </WidgetShell>
+  );
+}
+
+function ReservationPreviewModal({
+  isBusy,
+  meeting,
+  message,
+  onClose,
+  onContinue,
+}: {
+  isBusy: boolean;
+  meeting: Meeting;
+  message?: string;
+  onClose: () => void;
+  onContinue: () => void;
+}) {
+  return (
+    <div className="gafa-reservation-overlay" role="dialog" aria-modal="true" aria-labelledby="reservation-title">
+      <div className="gafa-reservation-sheet">
+        <button className="gafa-reservation-close" type="button" aria-label="Cerrar reserva" onClick={onClose}>
+          x
+        </button>
+
+        <div className="gafa-reservation-hero">
+          <span className="gafa-eyebrow">Detalle de reserva</span>
+          <h3 id="reservation-title">{meeting.name}</h3>
+          <p>
+            {formatDate(getMeetingStart(meeting))} · {formatTime(getMeetingStart(meeting))}
+          </p>
+        </div>
+
+        <div className="gafa-reservation-summary">
+          <div>
+            <span>Servicio</span>
+            <strong>{meeting.service?.name ?? meeting.serviceName ?? "Servicio"}</strong>
+          </div>
+          <div>
+            <span>Coach</span>
+            <strong>{getStaffName(meeting)}</strong>
+          </div>
+          <div>
+            <span>Sede</span>
+            <strong>{meeting.location?.name ?? "Por confirmar"}</strong>
+          </div>
+          <div>
+            <span>Disponibilidad</span>
+            <strong>{getAvailabilityText(meeting)}</strong>
+          </div>
+        </div>
+
+        <ol className="gafa-reservation-steps">
+          <li>
+            <strong>1. Confirma tu clase</strong>
+            <span>Revisa sede, coach, horario y disponibilidad.</span>
+          </li>
+          <li>
+            <strong>2. Inicia sesion</strong>
+            <span>Si el cliente no esta logueado, aqui se muestra login o registro.</span>
+          </li>
+          <li>
+            <strong>3. Usa credito o compra</strong>
+            <span>Si no tiene creditos, el flujo ofrece paquete, membresia o pago.</span>
+          </li>
+        </ol>
+
+        {message ? <p className="gafa-sdk-state gafa-sdk-state--success">{message}</p> : null}
+
+        <div className="gafa-reservation-actions">
+          <button className="gafa-sdk-button" type="button" disabled={isBusy || isSoldOut(meeting)} onClick={onContinue}>
+            {isBusy ? "Abriendo checkout..." : "Continuar reserva"}
+          </button>
+          <button className="gafa-sdk-button gafa-sdk-button--secondary" type="button" onClick={onClose}>
+            Seguir viendo horarios
+          </button>
+        </div>
+      </div>
+    </div>
   );
 }
 
@@ -370,6 +455,14 @@ function formatTime(value: string) {
   }).format(new Date(value));
 }
 
+function formatDate(value: string) {
+  return new Intl.DateTimeFormat("es-MX", {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+  }).format(new Date(value));
+}
+
 function getMeetingStart(meeting: Meeting): string {
   return meeting.startsAt ?? meeting.start ?? meeting.startTime ?? new Date().toISOString();
 }
@@ -409,6 +502,16 @@ function isSoldOut(meeting: Meeting): boolean {
   }
 
   return false;
+}
+
+function getAvailabilityText(meeting: Meeting): string {
+  if (meeting.isReserved) return "Ya reservado";
+  if (typeof meeting.available === "number" && typeof meeting.capacity === "number") {
+    return `${meeting.available}/${meeting.capacity} lugares`;
+  }
+  if (meeting.availability === "waitlist") return "Lista de espera";
+  if (isSoldOut(meeting)) return "Sin lugares";
+  return "Disponible";
 }
 
 function AvailabilityPill({ meeting }: { meeting: Meeting }) {

--- a/packages/react-sdk/src/sdk/widgets/CalendarWidget.tsx
+++ b/packages/react-sdk/src/sdk/widgets/CalendarWidget.tsx
@@ -1,0 +1,159 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { WidgetShell } from "./WidgetShell";
+import type { GafaClient, Meeting } from "../client/types";
+
+export type CalendarWidgetProps = {
+  client?: GafaClient;
+  limit?: number;
+  filters?: {
+    brand?: boolean | string;
+    location?: boolean | string;
+    service?: boolean | string;
+    staff?: boolean | string;
+    room?: boolean | string;
+    brandId?: number;
+    locationId?: number;
+    serviceId?: number;
+    staffId?: number;
+  };
+  visualization?: string;
+  showDescription?: boolean;
+};
+
+export function CalendarWidget({
+  client,
+  filters = {},
+  visualization = "agenda",
+  showDescription = false,
+}: CalendarWidgetProps) {
+  const query = useQuery({
+    queryKey: ["meetings", filters],
+    queryFn: async () => {
+      if (!client) {
+        return demoMeetings();
+      }
+
+      const brands = await client.listBrands();
+      const brand = brands[0];
+      if (!brand) {
+        return [];
+      }
+
+      const locations = await client.listLocations(brand.slug);
+      const location = locations[0];
+      if (!location) {
+        return [];
+      }
+
+      return client.listMeetings({
+        locationId: location.id,
+        ...defaultMeetingRange(),
+      });
+    },
+  });
+
+  const meetingsByDay = useMemo(() => groupMeetingsByDay(query.data ?? []), [query.data]);
+
+  return (
+    <WidgetShell
+      eyebrow="Reservas"
+      title="Calendario de servicios"
+      description="Una agenda mobile-first para encontrar clases, servicios y horarios disponibles."
+    >
+      {query.isLoading ? <p className="gafa-sdk__state">Cargando calendario...</p> : null}
+      {query.isError ? (
+        <p className="gafa-sdk__state gafa-sdk__state--error">No pudimos cargar el calendario.</p>
+      ) : null}
+      <div className="gafa-calendar" data-visualization={visualization}>
+        {Object.entries(meetingsByDay).length === 0 ? (
+          <div className="gafa-empty-state">
+            <strong>No hay horarios disponibles</strong>
+            <span>Prueba cambiando los filtros o seleccionando otra ubicacion.</span>
+          </div>
+        ) : (
+          Object.entries(meetingsByDay).map(([day, meetings]) => (
+            <section className="gafa-day-group" key={day}>
+              <h3>{day}</h3>
+              <div className="gafa-meeting-list">
+                {meetings.map((meeting) => (
+                  <article className="gafa-meeting-card" key={meeting.id}>
+                    <div>
+                      <span className="gafa-meeting-time">{formatTime(meeting.startsAt)}</span>
+                      <h4>{meeting.name}</h4>
+                      <p>{meeting.service?.name ?? meeting.serviceName ?? meeting.staff?.name ?? "Servicio"}</p>
+                      {showDescription && meeting.description ? <p>{meeting.description}</p> : null}
+                    </div>
+                    <button className="gafa-button" type="button">
+                      Reservar
+                    </button>
+                  </article>
+                ))}
+              </div>
+            </section>
+          ))
+        )}
+      </div>
+    </WidgetShell>
+  );
+}
+
+function groupMeetingsByDay(meetings: Meeting[]) {
+  return meetings.reduce<Record<string, Meeting[]>>((groups, meeting) => {
+    const day = new Intl.DateTimeFormat("es-MX", {
+      weekday: "long",
+      month: "long",
+      day: "numeric",
+    }).format(new Date(meeting.startsAt));
+
+    groups[day] = groups[day] ?? [];
+    groups[day].push(meeting);
+    return groups;
+  }, {});
+}
+
+function formatTime(value: string) {
+  return new Intl.DateTimeFormat("es-MX", {
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(new Date(value));
+}
+
+function defaultMeetingRange() {
+  const start = new Date();
+  const end = new Date();
+  end.setDate(start.getDate() + 14);
+
+  return {
+    from: start.toISOString().slice(0, 10),
+    to: end.toISOString().slice(0, 10),
+  };
+}
+
+function demoMeetings(): Meeting[] {
+  const first = new Date();
+  first.setHours(8, 0, 0, 0);
+
+  const second = new Date();
+  second.setDate(second.getDate() + 1);
+  second.setHours(18, 30, 0, 0);
+
+  return [
+    {
+      id: 1,
+      name: "Functional Training",
+      startsAt: first.toISOString(),
+      staff: { id: 1, name: "Coach Demo" },
+      service: { id: 1, name: "Training" },
+      availability: "available",
+    },
+    {
+      id: 2,
+      name: "Yoga Flow",
+      startsAt: second.toISOString(),
+      staff: { id: 2, name: "Coach Wellness" },
+      service: { id: 2, name: "Yoga" },
+      availability: "waitlist",
+    },
+  ];
+}

--- a/packages/react-sdk/src/sdk/widgets/CalendarWidget.tsx
+++ b/packages/react-sdk/src/sdk/widgets/CalendarWidget.tsx
@@ -195,10 +195,11 @@ export function CalendarWidget({
                       <span className="gafa-meeting-time">{formatTime(getMeetingStart(meeting))}</span>
                       <h4>{meeting.name}</h4>
                       <p>{meeting.service?.name ?? meeting.serviceName ?? meeting.staff?.name ?? "Servicio"}</p>
-                      <p className="gafa-meeting-meta">
-                        {getStaffName(meeting)}
-                        {meeting.location?.name ? ` · ${meeting.location.name}` : ""}
-                      </p>
+                      <div className="gafa-meeting-meta">
+                        <span className="gafa-meeting-chip">{getStaffName(meeting)}</span>
+                        {meeting.location?.name ? <span className="gafa-meeting-chip">{meeting.location.name}</span> : null}
+                        {meeting.durationMinutes ? <span className="gafa-meeting-chip">{meeting.durationMinutes} min</span> : null}
+                      </div>
                       {showDescription && meeting.description ? <p>{meeting.description}</p> : null}
                     </div>
                     <div className="gafa-meeting-card__aside">

--- a/packages/react-sdk/src/sdk/widgets/CalendarWidget.tsx
+++ b/packages/react-sdk/src/sdk/widgets/CalendarWidget.tsx
@@ -28,6 +28,12 @@ type CalendarFiltersState = {
   staffId?: number;
 };
 
+type ReservationState = {
+  meetingId?: number;
+  error?: string;
+  success?: string;
+};
+
 export function CalendarWidget({
   client,
   filters = {},
@@ -36,6 +42,7 @@ export function CalendarWidget({
   showDescription = false,
 }: CalendarWidgetProps) {
   const [selectedFilters, setSelectedFilters] = useState<CalendarFiltersState>({});
+  const [reservation, setReservation] = useState<ReservationState>({});
   const range = useMemo(() => defaultMeetingRange(), []);
 
   const brandsQuery = useQuery({
@@ -118,6 +125,31 @@ export function CalendarWidget({
   const isLoading = brandsQuery.isLoading || locationsQuery.isLoading || meetingsQuery.isLoading;
   const hasError = brandsQuery.isError || locationsQuery.isError || servicesQuery.isError || staffQuery.isError || meetingsQuery.isError;
 
+  async function handleReserve(meeting: Meeting) {
+    if (!client || isSoldOut(meeting) || reservation.meetingId) {
+      return;
+    }
+
+    setReservation({ meetingId: meeting.id });
+
+    try {
+      await client.openReservationCheckout({
+        meetingId: meeting.id,
+        brandSlug: getMeetingBrandSlug(meeting, activeBrand),
+        locationSlug: getMeetingLocationSlug(meeting, activeLocation),
+        targetSelector: '[data-gf-theme="fancy"]',
+      });
+
+      setReservation({
+        success: "Abrimos el flujo de reserva.",
+      });
+    } catch (error) {
+      setReservation({
+        error: error instanceof Error ? error.message : "No pudimos abrir la reserva.",
+      });
+    }
+  }
+
   return (
     <WidgetShell
       eyebrow="Reservas"
@@ -139,6 +171,12 @@ export function CalendarWidget({
       {isLoading ? <p className="gafa-sdk-state">Cargando calendario...</p> : null}
       {hasError ? (
         <p className="gafa-sdk-state gafa-sdk-state--error">No pudimos cargar el calendario.</p>
+      ) : null}
+      {reservation.error ? (
+        <p className="gafa-sdk-state gafa-sdk-state--error">{reservation.error}</p>
+      ) : null}
+      {reservation.success ? (
+        <p className="gafa-sdk-state gafa-sdk-state--success">{reservation.success}</p>
       ) : null}
       <div className="gafa-calendar" data-visualization={visualization}>
         {!isLoading && Object.entries(meetingsByDay).length === 0 ? (
@@ -165,8 +203,19 @@ export function CalendarWidget({
                     </div>
                     <div className="gafa-meeting-card__aside">
                       <AvailabilityPill meeting={meeting} />
-                      <button className="gafa-sdk-button" disabled={isSoldOut(meeting)} type="button">
-                        {meeting.isReserved ? "Reservado" : isSoldOut(meeting) ? "Sin lugares" : "Reservar"}
+                      <button
+                        className="gafa-sdk-button"
+                        disabled={isSoldOut(meeting) || reservation.meetingId === meeting.id}
+                        type="button"
+                        onClick={() => handleReserve(meeting)}
+                      >
+                        {reservation.meetingId === meeting.id
+                          ? "Abriendo..."
+                          : meeting.isReserved
+                            ? "Reservado"
+                            : isSoldOut(meeting)
+                              ? "Sin lugares"
+                              : "Reservar"}
                       </button>
                     </div>
                   </article>
@@ -329,6 +378,26 @@ function getStaffName(meeting: Meeting): string {
   if (!meeting.staff) return "Staff por confirmar";
 
   return [meeting.staff.name, meeting.staff.lastname].filter(Boolean).join(" ");
+}
+
+function getMeetingBrandSlug(meeting: Meeting, activeBrand?: Brand): string {
+  const brandSlug = meeting.location?.brand?.slug ?? meeting.brandSlug ?? activeBrand?.slug;
+
+  if (!brandSlug) {
+    throw new Error("No se encontro la marca para abrir la reserva.");
+  }
+
+  return brandSlug;
+}
+
+function getMeetingLocationSlug(meeting: Meeting, activeLocation?: Location): string {
+  const locationSlug = meeting.location?.slug ?? meeting.locationSlug ?? activeLocation?.slug;
+
+  if (!locationSlug) {
+    throw new Error("No se encontro la ubicacion para abrir la reserva.");
+  }
+
+  return locationSlug;
 }
 
 function isSoldOut(meeting: Meeting): boolean {

--- a/packages/react-sdk/src/sdk/widgets/CalendarWidget.tsx
+++ b/packages/react-sdk/src/sdk/widgets/CalendarWidget.tsx
@@ -1,7 +1,7 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { WidgetShell } from "./WidgetShell";
-import type { GafaClient, Meeting } from "../client/types";
+import type { Brand, GafaClient, Location, Meeting, Service, StaffMember } from "../client/types";
 
 export type CalendarWidgetProps = {
   client?: GafaClient;
@@ -21,39 +21,102 @@ export type CalendarWidgetProps = {
   showDescription?: boolean;
 };
 
+type CalendarFiltersState = {
+  brandSlug?: string;
+  locationId?: number;
+  serviceId?: number;
+  staffId?: number;
+};
+
 export function CalendarWidget({
   client,
   filters = {},
+  limit,
   visualization = "agenda",
   showDescription = false,
 }: CalendarWidgetProps) {
-  const query = useQuery({
-    queryKey: ["meetings", filters],
+  const [selectedFilters, setSelectedFilters] = useState<CalendarFiltersState>({});
+  const range = useMemo(() => defaultMeetingRange(), []);
+
+  const brandsQuery = useQuery({
+    queryKey: ["calendar", "brands"],
     queryFn: async () => {
-      if (!client) {
-        return demoMeetings();
-      }
+      if (!client) return demoBrands();
+      return client.listBrands();
+    },
+  });
 
-      const brands = await client.listBrands();
-      const brand = brands[0];
-      if (!brand) {
-        return [];
-      }
+  const activeBrand = useMemo(
+    () => findActiveBrand(brandsQuery.data ?? [], selectedFilters.brandSlug, filters.brandId),
+    [brandsQuery.data, filters.brandId, selectedFilters.brandSlug],
+  );
 
-      const locations = await client.listLocations(brand.slug);
-      const location = locations[0];
-      if (!location) {
-        return [];
-      }
+  const locationsQuery = useQuery({
+    enabled: Boolean(activeBrand) || !client,
+    queryKey: ["calendar", "locations", activeBrand?.slug],
+    queryFn: async () => {
+      if (!client) return demoLocations();
+      return client.listLocations(activeBrand?.slug);
+    },
+  });
 
+  const activeLocation = useMemo(
+    () => findActiveLocation(locationsQuery.data ?? [], selectedFilters.locationId, filters.locationId),
+    [filters.locationId, locationsQuery.data, selectedFilters.locationId],
+  );
+
+  const servicesQuery = useQuery({
+    enabled: Boolean(activeBrand) || !client,
+    queryKey: ["calendar", "services", activeBrand?.slug],
+    queryFn: async () => {
+      if (!client) return demoServices();
+      return client.listServices(activeBrand?.slug);
+    },
+  });
+
+  const staffQuery = useQuery({
+    enabled: Boolean(activeBrand) || !client,
+    queryKey: ["calendar", "staff", activeBrand?.slug],
+    queryFn: async () => {
+      if (!client) return demoStaff();
+      return client.listStaff(activeBrand?.slug);
+    },
+  });
+
+  const meetingsQuery = useQuery({
+    enabled: Boolean(activeLocation) || !client,
+    queryKey: [
+      "calendar",
+      "meetings",
+      activeLocation?.id,
+      selectedFilters.serviceId,
+      selectedFilters.staffId,
+      range.from,
+      range.to,
+    ],
+    queryFn: async () => {
+      if (!client) return demoMeetings();
       return client.listMeetings({
-        locationId: location.id,
-        ...defaultMeetingRange(),
+        locationId: activeLocation?.id,
+        serviceId: selectedFilters.serviceId ?? filters.serviceId,
+        staffId: selectedFilters.staffId ?? filters.staffId,
+        ...range,
       });
     },
   });
 
-  const meetingsByDay = useMemo(() => groupMeetingsByDay(query.data ?? []), [query.data]);
+  const filteredMeetings = useMemo(
+    () =>
+      applyLocalMeetingFilters(meetingsQuery.data ?? [], {
+        serviceId: selectedFilters.serviceId ?? filters.serviceId,
+        staffId: selectedFilters.staffId ?? filters.staffId,
+      }).slice(0, limit),
+    [filters.serviceId, filters.staffId, limit, meetingsQuery.data, selectedFilters.serviceId, selectedFilters.staffId],
+  );
+
+  const meetingsByDay = useMemo(() => groupMeetingsByDay(filteredMeetings), [filteredMeetings]);
+  const isLoading = brandsQuery.isLoading || locationsQuery.isLoading || meetingsQuery.isLoading;
+  const hasError = brandsQuery.isError || locationsQuery.isError || servicesQuery.isError || staffQuery.isError || meetingsQuery.isError;
 
   return (
     <WidgetShell
@@ -61,12 +124,24 @@ export function CalendarWidget({
       title="Calendario de servicios"
       description="Una agenda mobile-first para encontrar clases, servicios y horarios disponibles."
     >
-      {query.isLoading ? <p className="gafa-sdk__state">Cargando calendario...</p> : null}
-      {query.isError ? (
+      <CalendarFilterBar
+        activeBrandSlug={activeBrand?.slug}
+        activeLocationId={activeLocation?.id}
+        brands={brandsQuery.data ?? []}
+        filters={filters}
+        locations={locationsQuery.data ?? []}
+        onChange={setSelectedFilters}
+        selected={selectedFilters}
+        services={servicesQuery.data ?? []}
+        staff={staffQuery.data ?? []}
+      />
+
+      {isLoading ? <p className="gafa-sdk__state">Cargando calendario...</p> : null}
+      {hasError ? (
         <p className="gafa-sdk__state gafa-sdk__state--error">No pudimos cargar el calendario.</p>
       ) : null}
       <div className="gafa-calendar" data-visualization={visualization}>
-        {Object.entries(meetingsByDay).length === 0 ? (
+        {!isLoading && Object.entries(meetingsByDay).length === 0 ? (
           <div className="gafa-empty-state">
             <strong>No hay horarios disponibles</strong>
             <span>Prueba cambiando los filtros o seleccionando otra ubicacion.</span>
@@ -78,15 +153,22 @@ export function CalendarWidget({
               <div className="gafa-meeting-list">
                 {meetings.map((meeting) => (
                   <article className="gafa-meeting-card" key={meeting.id}>
-                    <div>
-                      <span className="gafa-meeting-time">{formatTime(meeting.startsAt)}</span>
+                    <div className="gafa-meeting-card__body">
+                      <span className="gafa-meeting-time">{formatTime(getMeetingStart(meeting))}</span>
                       <h4>{meeting.name}</h4>
                       <p>{meeting.service?.name ?? meeting.serviceName ?? meeting.staff?.name ?? "Servicio"}</p>
+                      <p className="gafa-meeting-meta">
+                        {getStaffName(meeting)}
+                        {meeting.location?.name ? ` · ${meeting.location.name}` : ""}
+                      </p>
                       {showDescription && meeting.description ? <p>{meeting.description}</p> : null}
                     </div>
-                    <button className="gafa-button" type="button">
-                      Reservar
-                    </button>
+                    <div className="gafa-meeting-card__aside">
+                      <AvailabilityPill meeting={meeting} />
+                      <button className="gafa-sdk-button" disabled={isSoldOut(meeting)} type="button">
+                        {meeting.isReserved ? "Reservado" : isSoldOut(meeting) ? "Sin lugares" : "Reservar"}
+                      </button>
+                    </div>
                   </article>
                 ))}
               </div>
@@ -98,13 +180,132 @@ export function CalendarWidget({
   );
 }
 
+function CalendarFilterBar({
+  activeBrandSlug,
+  activeLocationId,
+  brands,
+  filters,
+  locations,
+  onChange,
+  selected,
+  services,
+  staff,
+}: {
+  activeBrandSlug?: string;
+  activeLocationId?: number;
+  brands: Brand[];
+  filters: NonNullable<CalendarWidgetProps["filters"]>;
+  locations: Location[];
+  onChange: React.Dispatch<React.SetStateAction<CalendarFiltersState>>;
+  selected: CalendarFiltersState;
+  services: Service[];
+  staff: StaffMember[];
+}) {
+  const shouldShowFilters = filters.brand || filters.location || filters.service || filters.staff;
+
+  if (!shouldShowFilters) {
+    return null;
+  }
+
+  return (
+    <div className="gafa-calendar-filters" aria-label="Filtros de calendario">
+      {filters.brand ? (
+        <label>
+          Marca
+          <select
+            value={selected.brandSlug ?? activeBrandSlug ?? ""}
+            onChange={(event) =>
+              onChange((current) => ({
+                ...current,
+                brandSlug: event.target.value || undefined,
+                locationId: undefined,
+              }))
+            }
+          >
+            {brands.map((brand) => (
+              <option key={brand.slug} value={brand.slug}>
+                {brand.name}
+              </option>
+            ))}
+          </select>
+        </label>
+      ) : null}
+
+      {filters.location ? (
+        <label>
+          Ubicacion
+          <select
+            value={selected.locationId ?? activeLocationId ?? ""}
+            onChange={(event) =>
+              onChange((current) => ({
+                ...current,
+                locationId: toOptionalNumber(event.target.value),
+              }))
+            }
+          >
+            {locations.map((location) => (
+              <option key={location.id} value={location.id}>
+                {location.name}
+              </option>
+            ))}
+          </select>
+        </label>
+      ) : null}
+
+      {filters.service ? (
+        <label>
+          Servicio
+          <select
+            value={selected.serviceId ?? ""}
+            onChange={(event) =>
+              onChange((current) => ({
+                ...current,
+                serviceId: toOptionalNumber(event.target.value),
+              }))
+            }
+          >
+            <option value="">Todos</option>
+            {services.map((service) => (
+              <option key={service.id} value={service.id}>
+                {service.name}
+              </option>
+            ))}
+          </select>
+        </label>
+      ) : null}
+
+      {filters.staff ? (
+        <label>
+          Staff
+          <select
+            value={selected.staffId ?? ""}
+            onChange={(event) =>
+              onChange((current) => ({
+                ...current,
+                staffId: toOptionalNumber(event.target.value),
+              }))
+            }
+          >
+            <option value="">Todos</option>
+            {staff.map((staffMember) => (
+              <option key={staffMember.id} value={staffMember.id}>
+                {staffMember.name}
+              </option>
+            ))}
+          </select>
+        </label>
+      ) : null}
+    </div>
+  );
+}
+
 function groupMeetingsByDay(meetings: Meeting[]) {
   return meetings.reduce<Record<string, Meeting[]>>((groups, meeting) => {
     const day = new Intl.DateTimeFormat("es-MX", {
       weekday: "long",
       month: "long",
       day: "numeric",
-    }).format(new Date(meeting.startsAt));
+    }).format(new Date(getMeetingStart(meeting)));
 
     groups[day] = groups[day] ?? [];
     groups[day].push(meeting);
@@ -117,6 +318,98 @@ function formatTime(value: string) {
     hour: "2-digit",
     minute: "2-digit",
   }).format(new Date(value));
+}
+
+function getMeetingStart(meeting: Meeting): string {
+  return meeting.startsAt ?? meeting.start ?? meeting.startTime ?? new Date().toISOString();
+}
+
+function getStaffName(meeting: Meeting): string {
+  if (meeting.staffName) return meeting.staffName;
+  if (!meeting.staff) return "Staff por confirmar";
+
+  return [meeting.staff.name, meeting.staff.lastname].filter(Boolean).join(" ");
+}
+
+function isSoldOut(meeting: Meeting): boolean {
+  if (meeting.availability === "sold-out") return true;
+  if (typeof meeting.available === "number") return meeting.available <= 0 && !meeting.isReserved;
+  if (typeof meeting.availability === "object" && meeting.availability.capacity) {
+    return (meeting.availability.reserved ?? 0) >= meeting.availability.capacity;
+  }
+
+  return false;
+}
+
+function AvailabilityPill({ meeting }: { meeting: Meeting }) {
+  if (meeting.isReserved) {
+    return <span className="gafa-availability-pill gafa-availability-pill--reserved">Reservado</span>;
+  }
+
+  if (typeof meeting.available === "number" && typeof meeting.capacity === "number") {
+    return (
+      <span className="gafa-availability-pill">
+        {meeting.available}/{meeting.capacity} lugares
+      </span>
+    );
+  }
+
+  if (meeting.availability === "waitlist") {
+    return <span className="gafa-availability-pill gafa-availability-pill--waitlist">Waitlist</span>;
+  }
+
+  if (isSoldOut(meeting)) {
+    return <span className="gafa-availability-pill gafa-availability-pill--sold-out">Sin lugares</span>;
+  }
+
+  return <span className="gafa-availability-pill">Disponible</span>;
+}
+
+function applyLocalMeetingFilters(
+  meetings: Meeting[],
+  filters: Pick<CalendarFiltersState, "serviceId" | "staffId">,
+): Meeting[] {
+  return meetings.filter((meeting) => {
+    if (filters.serviceId && meeting.service?.id !== filters.serviceId && meeting.serviceId !== filters.serviceId) {
+      return false;
+    }
+
+    if (filters.staffId && meeting.staff?.id !== filters.staffId && meeting.staffId !== filters.staffId) {
+      return false;
+    }
+
+    return true;
+  });
+}
+
+function findActiveBrand(brands: Brand[], selectedSlug?: string, defaultId?: number): Brand | undefined {
+  if (selectedSlug) {
+    return brands.find((brand) => brand.slug === selectedSlug);
+  }
+
+  if (defaultId) {
+    return brands.find((brand) => brand.id === defaultId);
+  }
+
+  return brands[0];
+}
+
+function findActiveLocation(locations: Location[], selectedId?: number, defaultId?: number): Location | undefined {
+  if (selectedId) {
+    return locations.find((location) => location.id === selectedId);
+  }
+
+  if (defaultId) {
+    return locations.find((location) => location.id === defaultId);
+  }
+
+  return locations[0];
+}
+
+function toOptionalNumber(value: string): number | undefined {
+  if (!value) return undefined;
+  const parsed = Number(value);
+  return Number.isNaN(parsed) ? undefined : parsed;
 }
 
 function defaultMeetingRange() {
@@ -143,6 +436,10 @@ function demoMeetings(): Meeting[] {
       id: 1,
       name: "Functional Training",
       startsAt: first.toISOString(),
+      durationMinutes: 50,
+      available: 6,
+      capacity: 14,
+      location: demoLocations()[0],
       staff: { id: 1, name: "Coach Demo" },
       service: { id: 1, name: "Training" },
       availability: "available",
@@ -151,9 +448,35 @@ function demoMeetings(): Meeting[] {
       id: 2,
       name: "Yoga Flow",
       startsAt: second.toISOString(),
+      durationMinutes: 45,
+      available: 0,
+      capacity: 12,
+      location: demoLocations()[0],
       staff: { id: 2, name: "Coach Wellness" },
       service: { id: 2, name: "Yoga" },
       availability: "waitlist",
     },
+  ];
+}
+
+function demoBrands(): Brand[] {
+  return [{ id: 1, name: "Demo Studio", slug: "demo-studio" }];
+}
+
+function demoLocations(): Location[] {
+  return [{ id: 1, name: "Roma Norte", slug: "roma-norte", brandSlug: "demo-studio" }];
+}
+
+function demoServices(): Service[] {
+  return [
+    { id: 1, name: "Training", durationMinutes: 50 },
+    { id: 2, name: "Yoga", durationMinutes: 45 },
+  ];
+}
+
+function demoStaff(): StaffMember[] {
+  return [
+    { id: 1, name: "Coach Demo" },
+    { id: 2, name: "Coach Wellness" },
   ];
 }

--- a/packages/react-sdk/src/sdk/widgets/CatalogWidget.tsx
+++ b/packages/react-sdk/src/sdk/widgets/CatalogWidget.tsx
@@ -43,7 +43,7 @@ export function CatalogWidget({ client, type = "packages", title, filterByName, 
     <WidgetShell
       eyebrow={getCatalogLabel(type)}
       title={title ?? getCatalogTitle(type)}
-      description="Cards mobile-first listas para conectarse al checkout moderno."
+      description="Elige el paquete ideal para reservar sin friccion."
     >
       {isLoading ? <p className="gafa-sdk-state">Cargando catalogo...</p> : null}
       {isError ? <p className="gafa-sdk-state gafa-sdk-state--error">No pudimos cargar el catalogo.</p> : null}

--- a/packages/react-sdk/src/sdk/widgets/CatalogWidget.tsx
+++ b/packages/react-sdk/src/sdk/widgets/CatalogWidget.tsx
@@ -45,23 +45,24 @@ export function CatalogWidget({ client, type = "packages", title, filterByName, 
       title={title ?? getCatalogTitle(type)}
       description="Cards mobile-first listas para conectarse al checkout moderno."
     >
-      {isLoading ? <p className="gafa-sdk__state">Cargando catalogo...</p> : null}
-      {isError ? <p className="gafa-sdk__state gafa-sdk__state--error">No pudimos cargar el catalogo.</p> : null}
-      <div className="gafa-sdk__cards">
+      {isLoading ? <p className="gafa-sdk-state">Cargando catalogo...</p> : null}
+      {isError ? <p className="gafa-sdk-state gafa-sdk-state--error">No pudimos cargar el catalogo.</p> : null}
+      <div className="gafa-sdk-grid">
         {(data ?? []).map((item) => (
-          <article className="gafa-sdk__card" key={`${type}-${item.id}`}>
+          <article className="gafa-sdk-card gafa-catalog-card" key={`${type}-${item.id}`}>
             <div>
-              <p className="gafa-sdk__meta">{item.brandName}</p>
+              <p className="gafa-sdk-kicker">{item.brandName}</p>
               <h3>{item.name}</h3>
               {item.description ? <p>{item.description}</p> : null}
+              {item.priceLabel ? <strong className="gafa-catalog-price">{item.priceLabel}</strong> : null}
             </div>
-            <button className="gafa-sdk__button" type="button">
+            <button className="gafa-sdk-button" type="button">
               Comprar
             </button>
           </article>
         ))}
       </div>
-      {!isLoading && !isError && !data?.length ? <p className="gafa-sdk__state">No hay elementos para mostrar.</p> : null}
+      {!isLoading && !isError && !data?.length ? <p className="gafa-sdk-state">No hay elementos para mostrar.</p> : null}
     </WidgetShell>
   );
 }

--- a/packages/react-sdk/src/sdk/widgets/CatalogWidget.tsx
+++ b/packages/react-sdk/src/sdk/widgets/CatalogWidget.tsx
@@ -1,0 +1,159 @@
+import { useQuery } from "@tanstack/react-query";
+import type { CatalogItem, GafaClient } from "../client/types";
+import { WidgetShell } from "./WidgetShell";
+
+export type CatalogKind = "packages" | "memberships" | "services" | "staff";
+
+export type CatalogWidgetProps = {
+  client?: GafaClient;
+  type?: CatalogKind;
+  title?: string;
+  filterByName?: string | null;
+  filterByBrand?: string | null;
+};
+
+export function CatalogWidget({ client, type = "packages", title, filterByName, filterByBrand }: CatalogWidgetProps) {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["catalog", type, filterByName, filterByBrand],
+    queryFn: async () => {
+      if (!client) {
+        return demoItems(type);
+      }
+
+      const brands = await client.listBrands();
+      const visibleBrands = filterByBrand
+        ? brands.filter((brand) => brand.name.toLowerCase().includes(filterByBrand.toLowerCase()))
+        : brands;
+
+      const results = await Promise.all(
+        visibleBrands.map(async (brand) => {
+          const items = await getItemsForType(client, type, brand.slug);
+          return items.map((item) => ({ ...item, brandName: brand.name }));
+        }),
+      );
+
+      const items = results.flat();
+      if (!filterByName) return items;
+
+      return items.filter((item) => item.name.toLowerCase().includes(filterByName.toLowerCase()));
+    },
+  });
+
+  return (
+    <WidgetShell
+      eyebrow={getCatalogLabel(type)}
+      title={title ?? getCatalogTitle(type)}
+      description="Cards mobile-first listas para conectarse al checkout moderno."
+    >
+      {isLoading ? <p className="gafa-sdk__state">Cargando catalogo...</p> : null}
+      {isError ? <p className="gafa-sdk__state gafa-sdk__state--error">No pudimos cargar el catalogo.</p> : null}
+      <div className="gafa-sdk__cards">
+        {(data ?? []).map((item) => (
+          <article className="gafa-sdk__card" key={`${type}-${item.id}`}>
+            <div>
+              <p className="gafa-sdk__meta">{item.brandName}</p>
+              <h3>{item.name}</h3>
+              {item.description ? <p>{item.description}</p> : null}
+            </div>
+            <button className="gafa-sdk__button" type="button">
+              Comprar
+            </button>
+          </article>
+        ))}
+      </div>
+      {!isLoading && !isError && !data?.length ? <p className="gafa-sdk__state">No hay elementos para mostrar.</p> : null}
+    </WidgetShell>
+  );
+}
+
+async function getItemsForType(client: GafaClient, type: CatalogKind, brandSlug: string): Promise<CatalogItem[]> {
+  switch (type) {
+    case "memberships":
+      return client.listMemberships(brandSlug);
+    case "services":
+      return client.listServices(brandSlug);
+    case "staff":
+      return client.listStaff(brandSlug);
+    case "packages":
+    default:
+      return client.listCombos(brandSlug);
+  }
+}
+
+function getCatalogLabel(type: CatalogKind): string {
+  switch (type) {
+    case "memberships":
+      return "Membresias";
+    case "services":
+      return "Servicios";
+    case "staff":
+      return "Staff";
+    default:
+      return "Paquetes";
+  }
+}
+
+function demoItems(type: CatalogKind): Array<CatalogItem & { brandName: string }> {
+  const brandName = "Demo Studio";
+
+  if (type === "memberships") {
+    return [
+      {
+        id: 2,
+        name: "Mensual ilimitada",
+        description: "Membresia para clientes recurrentes.",
+        priceLabel: "$2,400 MXN",
+        type: "membership",
+        brandName,
+      },
+    ];
+  }
+
+  if (type === "services") {
+    return [
+      {
+        id: 3,
+        name: "Functional Training",
+        description: "Servicio de fuerza y acondicionamiento.",
+        type: "service",
+        brandName,
+      },
+    ];
+  }
+
+  if (type === "staff") {
+    return [
+      {
+        id: 4,
+        name: "Coach Demo",
+        description: "Entrenador principal.",
+        type: "staff",
+        brandName,
+      },
+    ];
+  }
+
+  return [
+    {
+      id: 1,
+      name: "10 clases",
+      description: "Paquete inicial para reservar en cualquier sede.",
+      priceLabel: "$1,200 MXN",
+      type: "combo",
+      brandName,
+    },
+  ];
+}
+
+function getCatalogTitle(type: CatalogKind): string {
+  switch (type) {
+    case "memberships":
+      return "Elige una membresia";
+    case "services":
+      return "Explora servicios";
+    case "staff":
+      return "Conoce al staff";
+    default:
+      return "Compra paquetes";
+  }
+}

--- a/packages/react-sdk/src/sdk/widgets/ProfileWidget.tsx
+++ b/packages/react-sdk/src/sdk/widgets/ProfileWidget.tsx
@@ -11,13 +11,16 @@ export function ProfileWidget({ combineWaitlist = false }: ProfileWidgetProps) {
     <WidgetShell
       eyebrow="Perfil"
       title="Tu cuenta en un solo lugar"
-      description="Datos personales, creditos, membresias, reservas futuras, historial y metodos de pago preparados para la nueva experiencia."
+      description="Perfil moderno para que cada cliente consulte reservas, creditos, membresias y metodos de pago sin salir del sitio."
     >
       <div className="gafa-sdk-profile-grid">
         <section className="gafa-sdk-panel">
           <span className="gafa-sdk-label">Datos</span>
           <h3>Perfil editable</h3>
           <p>Nombre, contacto, direccion y preferencias.</p>
+          <button className="gafa-sdk-button gafa-sdk-button--secondary" type="button">
+            Editar perfil
+          </button>
         </section>
         <section className="gafa-sdk-panel">
           <span className="gafa-sdk-label">Actividad</span>
@@ -27,6 +30,10 @@ export function ProfileWidget({ combineWaitlist = false }: ProfileWidgetProps) {
               ? "Waitlist combinado con proximas reservas."
               : "Waitlist separado para mantener el contrato actual."}
           </p>
+          <div className="gafa-profile-stats">
+            <span>5 creditos</span>
+            <span>2 reservas</span>
+          </div>
         </section>
       </div>
     </WidgetShell>

--- a/packages/react-sdk/src/sdk/widgets/ProfileWidget.tsx
+++ b/packages/react-sdk/src/sdk/widgets/ProfileWidget.tsx
@@ -1,0 +1,34 @@
+import type { GafaClient } from "../client/types";
+import { WidgetShell } from "./WidgetShell";
+
+export type ProfileWidgetProps = {
+  client?: GafaClient;
+  combineWaitlist?: boolean;
+};
+
+export function ProfileWidget({ combineWaitlist = false }: ProfileWidgetProps) {
+  return (
+    <WidgetShell
+      eyebrow="Perfil"
+      title="Tu cuenta en un solo lugar"
+      description="Datos personales, creditos, membresias, reservas futuras, historial y metodos de pago preparados para la nueva experiencia."
+    >
+      <div className="gafa-sdk-profile-grid">
+        <section className="gafa-sdk-panel">
+          <span className="gafa-sdk-label">Datos</span>
+          <strong>Perfil editable</strong>
+          <p>Nombre, contacto, direccion y preferencias.</p>
+        </section>
+        <section className="gafa-sdk-panel">
+          <span className="gafa-sdk-label">Actividad</span>
+          <strong>Reservas y waitlist</strong>
+          <p>
+            {combineWaitlist
+              ? "Waitlist combinado con proximas reservas."
+              : "Waitlist separado para mantener el contrato actual."}
+          </p>
+        </section>
+      </div>
+    </WidgetShell>
+  );
+}

--- a/packages/react-sdk/src/sdk/widgets/ProfileWidget.tsx
+++ b/packages/react-sdk/src/sdk/widgets/ProfileWidget.tsx
@@ -16,12 +16,12 @@ export function ProfileWidget({ combineWaitlist = false }: ProfileWidgetProps) {
       <div className="gafa-sdk-profile-grid">
         <section className="gafa-sdk-panel">
           <span className="gafa-sdk-label">Datos</span>
-          <strong>Perfil editable</strong>
+          <h3>Perfil editable</h3>
           <p>Nombre, contacto, direccion y preferencias.</p>
         </section>
         <section className="gafa-sdk-panel">
           <span className="gafa-sdk-label">Actividad</span>
-          <strong>Reservas y waitlist</strong>
+          <h3>Reservas y waitlist</h3>
           <p>
             {combineWaitlist
               ? "Waitlist combinado con proximas reservas."

--- a/packages/react-sdk/src/sdk/widgets/PurchaseButtonWidget.tsx
+++ b/packages/react-sdk/src/sdk/widgets/PurchaseButtonWidget.tsx
@@ -1,0 +1,52 @@
+import type { GafaClient } from "../client/types";
+import { WidgetShell } from "./WidgetShell";
+
+export type PurchaseButtonWidgetProps = {
+  client?: GafaClient;
+  hostElement?: Element;
+  comboId?: string | null;
+  membershipId?: string | null;
+  productId?: string | null;
+  reservationId?: string | null;
+  locationId?: string | null;
+  defaultStoreTab?: string | null;
+  noLoading?: boolean;
+};
+
+export function PurchaseButtonWidget({
+  comboId,
+  membershipId,
+  productId,
+  reservationId,
+  locationId,
+  defaultStoreTab,
+  noLoading = false,
+}: PurchaseButtonWidgetProps) {
+  const target =
+    comboId ??
+    membershipId ??
+    productId ??
+    "producto pendiente de configurar";
+
+  return (
+    <WidgetShell
+      eyebrow="Compra"
+      title="Boton de compra"
+      description="Este widget conectara botones externos con el checkout del nuevo SDK o con el flujo fancy legacy."
+    >
+      <button className="gafa-button" type="button">
+        Comprar {target}
+      </button>
+      {locationId ? (
+        <p className="gafa-muted">Ubicacion configurada: {locationId}</p>
+      ) : null}
+      {reservationId || defaultStoreTab || noLoading ? (
+        <p className="gafa-muted">
+          Opciones legacy detectadas: {reservationId ? `reserva ${reservationId}` : "sin reserva"}
+          {defaultStoreTab ? `, tab ${defaultStoreTab}` : ""}
+          {noLoading ? ", sin loader externo" : ""}
+        </p>
+      ) : null}
+    </WidgetShell>
+  );
+}

--- a/packages/react-sdk/src/sdk/widgets/WidgetShell.tsx
+++ b/packages/react-sdk/src/sdk/widgets/WidgetShell.tsx
@@ -1,0 +1,37 @@
+import type { PropsWithChildren, ReactNode } from "react";
+
+type WidgetShellProps = PropsWithChildren<{
+  eyebrow?: string;
+  title: string;
+  description?: string;
+  logoUrl?: string;
+  actions?: ReactNode;
+}>;
+
+export function WidgetShell({
+  eyebrow,
+  title,
+  description,
+  logoUrl,
+  actions,
+  children,
+}: WidgetShellProps) {
+  return (
+    <section className="gafa-widget-card">
+      <header className="gafa-widget-header">
+        <div className="gafa-widget-heading">
+          {logoUrl ? (
+            <img className="gafa-widget-logo" src={logoUrl} alt="" aria-hidden="true" />
+          ) : null}
+          <div>
+            {eyebrow ? <p className="gafa-eyebrow">{eyebrow}</p> : null}
+            <h2>{title}</h2>
+            {description ? <p className="gafa-muted">{description}</p> : null}
+          </div>
+        </div>
+        {actions ? <div className="gafa-widget-actions">{actions}</div> : null}
+      </header>
+      {children}
+    </section>
+  );
+}

--- a/packages/react-sdk/src/sdk/widgets/widgets.css
+++ b/packages/react-sdk/src/sdk/widgets/widgets.css
@@ -382,6 +382,112 @@
   color: var(--gafa-color-danger);
 }
 
+.gafa-reservation-overlay {
+  align-items: end;
+  background: rgba(15, 23, 42, 0.46);
+  display: grid;
+  inset: 0;
+  padding: var(--gafa-space-3);
+  position: fixed;
+  z-index: 40;
+}
+
+.gafa-reservation-sheet {
+  background:
+    radial-gradient(circle at 12% 0%, color-mix(in srgb, var(--gafa-color-accent) 16%, transparent), transparent 36%),
+    rgba(255, 255, 255, 0.96);
+  border: 1px solid rgba(255, 255, 255, 0.84);
+  border-radius: 30px 30px var(--gafa-radius-xl) var(--gafa-radius-xl);
+  box-shadow: 0 30px 90px rgba(15, 23, 42, 0.28);
+  display: grid;
+  gap: var(--gafa-space-4);
+  margin: 0 auto;
+  max-height: min(88vh, 760px);
+  max-width: 560px;
+  overflow: auto;
+  padding: var(--gafa-space-5);
+  position: relative;
+  width: 100%;
+}
+
+.gafa-reservation-close {
+  align-items: center;
+  appearance: none;
+  background: rgba(17, 24, 39, 0.08);
+  border: 0;
+  border-radius: var(--gafa-radius-pill);
+  color: var(--gafa-color-text);
+  cursor: pointer;
+  display: inline-flex;
+  font: inherit;
+  font-weight: 900;
+  height: 38px;
+  justify-content: center;
+  position: absolute;
+  right: var(--gafa-space-4);
+  top: var(--gafa-space-4);
+  width: 38px;
+}
+
+.gafa-reservation-hero {
+  display: grid;
+  gap: var(--gafa-space-2);
+  padding-right: 44px;
+}
+
+.gafa-reservation-hero h3 {
+  color: var(--gafa-color-text);
+  font-size: clamp(1.65rem, 8vw, 2.4rem);
+  letter-spacing: -0.045em;
+  line-height: 1;
+  margin: 0;
+}
+
+.gafa-reservation-hero p {
+  color: var(--gafa-color-muted-text);
+  margin: 0;
+}
+
+.gafa-reservation-summary {
+  display: grid;
+  gap: var(--gafa-space-2);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.gafa-reservation-summary div,
+.gafa-reservation-steps li {
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(17, 24, 39, 0.08);
+  border-radius: var(--gafa-radius-lg);
+  display: grid;
+  gap: 0.15rem;
+  padding: var(--gafa-space-3);
+}
+
+.gafa-reservation-summary span,
+.gafa-reservation-steps span {
+  color: var(--gafa-color-muted-text);
+  font-size: 0.82rem;
+}
+
+.gafa-reservation-summary strong,
+.gafa-reservation-steps strong {
+  color: var(--gafa-color-text);
+}
+
+.gafa-reservation-steps {
+  display: grid;
+  gap: var(--gafa-space-2);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.gafa-reservation-actions {
+  display: grid;
+  gap: var(--gafa-space-2);
+}
+
 .gafa-empty-state {
   background: rgba(255, 255, 255, 0.7);
   border: 1px dashed rgba(17, 24, 39, 0.14);
@@ -397,6 +503,14 @@
 }
 
 @media (min-width: 720px) {
+  .gafa-reservation-overlay {
+    align-items: center;
+  }
+
+  .gafa-reservation-actions {
+    grid-template-columns: 1fr 1fr;
+  }
+
   .gafa-calendar-filters {
     grid-template-columns: repeat(4, minmax(0, 1fr));
   }

--- a/packages/react-sdk/src/sdk/widgets/widgets.css
+++ b/packages/react-sdk/src/sdk/widgets/widgets.css
@@ -1,0 +1,137 @@
+.gafa-sdk-widget {
+  display: grid;
+  gap: var(--gafa-space-4);
+}
+
+.gafa-sdk-widget__eyebrow {
+  color: var(--gafa-color-primary);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.gafa-sdk-widget__header {
+  display: grid;
+  gap: var(--gafa-space-2);
+}
+
+.gafa-sdk-widget__title {
+  color: var(--gafa-color-text);
+  font-size: clamp(1.35rem, 7vw, 2rem);
+  line-height: 1.08;
+  margin: 0;
+}
+
+.gafa-sdk-widget__description {
+  color: var(--gafa-color-muted-text);
+  font-size: 0.98rem;
+  line-height: 1.55;
+  margin: 0;
+}
+
+.gafa-sdk-panel {
+  background: var(--gafa-color-surface);
+  border: 1px solid var(--gafa-color-border);
+  border-radius: var(--gafa-radius-lg);
+  box-shadow: var(--gafa-shadow-card);
+  padding: var(--gafa-space-4);
+}
+
+.gafa-sdk-grid {
+  display: grid;
+  gap: var(--gafa-space-3);
+}
+
+@media (min-width: 720px) {
+  .gafa-sdk-grid--columns {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.gafa-sdk-card {
+  background: var(--gafa-color-background);
+  border: 1px solid var(--gafa-color-border);
+  border-radius: var(--gafa-radius-md);
+  display: grid;
+  gap: var(--gafa-space-2);
+  padding: var(--gafa-space-4);
+}
+
+.gafa-sdk-card strong {
+  color: var(--gafa-color-text);
+}
+
+.gafa-sdk-card span,
+.gafa-sdk-card p {
+  color: var(--gafa-color-muted-text);
+  margin: 0;
+}
+
+.gafa-sdk-actions,
+.gafa-sdk-auth-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--gafa-space-2);
+}
+
+.gafa-sdk-button,
+.gafa-sdk-auth-tabs button {
+  align-items: center;
+  background: var(--gafa-color-primary);
+  border: 0;
+  border-radius: var(--gafa-radius-pill);
+  color: var(--gafa-color-primary-text);
+  cursor: pointer;
+  display: inline-flex;
+  font: inherit;
+  font-weight: 800;
+  justify-content: center;
+  min-height: 44px;
+  padding: 0.75rem 1rem;
+  text-decoration: none;
+}
+
+.gafa-sdk-button--secondary,
+.gafa-sdk-auth-tabs button[aria-pressed="false"] {
+  background: color-mix(in srgb, var(--gafa-color-primary) 12%, transparent);
+  color: var(--gafa-color-primary);
+}
+
+.gafa-sdk-form {
+  display: grid;
+  gap: var(--gafa-space-3);
+}
+
+.gafa-sdk-field {
+  display: grid;
+  gap: var(--gafa-space-1);
+}
+
+.gafa-sdk-field label {
+  color: var(--gafa-color-text);
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.gafa-sdk-field input {
+  background: var(--gafa-color-background);
+  border: 1px solid var(--gafa-color-border);
+  border-radius: var(--gafa-radius-md);
+  color: var(--gafa-color-text);
+  font: inherit;
+  min-height: 46px;
+  padding: 0.75rem 0.9rem;
+}
+
+.gafa-sdk-state {
+  border: 1px dashed var(--gafa-color-border);
+  border-radius: var(--gafa-radius-md);
+  color: var(--gafa-color-muted-text);
+  padding: var(--gafa-space-4);
+}
+
+.gafa-sdk-state--error {
+  border-color: var(--gafa-color-danger);
+  color: var(--gafa-color-danger);
+}

--- a/packages/react-sdk/src/sdk/widgets/widgets.css
+++ b/packages/react-sdk/src/sdk/widgets/widgets.css
@@ -1,83 +1,107 @@
-.gafa-sdk-widget {
+.gafa-widget-card {
   display: grid;
   gap: var(--gafa-space-4);
 }
 
-.gafa-sdk-widget__eyebrow {
+.gafa-widget-header {
+  display: grid;
+  gap: var(--gafa-space-3);
+}
+
+.gafa-widget-heading {
+  align-items: center;
+  display: flex;
+  gap: var(--gafa-space-3);
+}
+
+.gafa-widget-logo {
+  border-radius: var(--gafa-radius-md);
+  height: 42px;
+  object-fit: contain;
+  width: auto;
+}
+
+.gafa-eyebrow,
+.gafa-sdk-label,
+.gafa-sdk__meta {
   color: var(--gafa-color-primary);
-  font-size: 0.78rem;
-  font-weight: 800;
+  font-size: 0.76rem;
+  font-weight: 850;
   letter-spacing: 0.08em;
+  margin: 0;
   text-transform: uppercase;
 }
 
-.gafa-sdk-widget__header {
-  display: grid;
-  gap: var(--gafa-space-2);
-}
-
-.gafa-sdk-widget__title {
+.gafa-widget-card h2,
+.gafa-widget-card h3,
+.gafa-widget-card h4 {
   color: var(--gafa-color-text);
-  font-size: clamp(1.35rem, 7vw, 2rem);
-  line-height: 1.08;
+  font-family: var(--gafa-font-heading);
+  letter-spacing: -0.035em;
   margin: 0;
 }
 
-.gafa-sdk-widget__description {
+.gafa-widget-card h2 {
+  font-size: clamp(1.65rem, 8vw, 2.35rem);
+  line-height: 1.02;
+}
+
+.gafa-widget-card h3 {
+  font-size: 1.2rem;
+}
+
+.gafa-widget-card h4 {
+  font-size: 1.08rem;
+}
+
+.gafa-muted,
+.gafa-widget-card p {
   color: var(--gafa-color-muted-text);
   font-size: 0.98rem;
   line-height: 1.55;
   margin: 0;
 }
 
-.gafa-sdk-panel {
-  background: var(--gafa-color-surface);
-  border: 1px solid var(--gafa-color-border);
+.gafa-sdk-panel,
+.gafa-sdk__card {
+  background: color-mix(in srgb, var(--gafa-color-surface) 94%, white);
+  border: 1px solid color-mix(in srgb, var(--gafa-color-border) 70%, transparent);
   border-radius: var(--gafa-radius-lg);
   box-shadow: var(--gafa-shadow-card);
+  display: grid;
+  gap: var(--gafa-space-3);
   padding: var(--gafa-space-4);
 }
 
-.gafa-sdk-grid {
+.gafa-sdk-profile-grid,
+.gafa-sdk__cards {
   display: grid;
   gap: var(--gafa-space-3);
 }
 
-@media (min-width: 720px) {
-  .gafa-sdk-grid--columns {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
+.gafa-sdk__card {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.82), rgba(255, 255, 255, 0.94)),
+    var(--gafa-color-surface);
 }
 
-.gafa-sdk-card {
-  background: var(--gafa-color-background);
-  border: 1px solid var(--gafa-color-border);
-  border-radius: var(--gafa-radius-md);
+.gafa-sdk__card > div {
   display: grid;
   gap: var(--gafa-space-2);
-  padding: var(--gafa-space-4);
-}
-
-.gafa-sdk-card strong {
-  color: var(--gafa-color-text);
-}
-
-.gafa-sdk-card span,
-.gafa-sdk-card p {
-  color: var(--gafa-color-muted-text);
-  margin: 0;
 }
 
 .gafa-sdk-actions,
 .gafa-sdk-auth-tabs {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
   gap: var(--gafa-space-2);
+  grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
 .gafa-sdk-button,
+.gafa-sdk-primary-button,
 .gafa-sdk-auth-tabs button {
   align-items: center;
+  appearance: none;
   background: var(--gafa-color-primary);
   border: 0;
   border-radius: var(--gafa-radius-pill);
@@ -85,17 +109,25 @@
   cursor: pointer;
   display: inline-flex;
   font: inherit;
-  font-weight: 800;
+  font-weight: 850;
   justify-content: center;
-  min-height: 44px;
-  padding: 0.75rem 1rem;
+  min-height: 48px;
+  padding: 0.78rem 1.1rem;
+  text-align: center;
   text-decoration: none;
+  transition: opacity 160ms ease, transform 160ms ease;
+  width: 100%;
+}
+
+.gafa-sdk-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
 }
 
 .gafa-sdk-button--secondary,
 .gafa-sdk-auth-tabs button[aria-pressed="false"] {
-  background: color-mix(in srgb, var(--gafa-color-primary) 12%, transparent);
-  color: var(--gafa-color-primary);
+  background: color-mix(in srgb, var(--gafa-color-primary) 9%, var(--gafa-color-surface));
+  color: var(--gafa-color-text);
 }
 
 .gafa-sdk-form {
@@ -104,34 +136,37 @@
 }
 
 .gafa-sdk-field {
+  color: var(--gafa-color-text);
   display: grid;
+  font-size: 0.9rem;
+  font-weight: 750;
   gap: var(--gafa-space-1);
 }
 
-.gafa-sdk-field label {
-  color: var(--gafa-color-text);
-  font-size: 0.85rem;
-  font-weight: 700;
-}
-
-.gafa-sdk-field input {
-  background: var(--gafa-color-background);
+.gafa-sdk-field input,
+.gafa-sdk-field select {
+  appearance: none;
+  background: color-mix(in srgb, var(--gafa-color-surface) 92%, white);
   border: 1px solid var(--gafa-color-border);
   border-radius: var(--gafa-radius-md);
   color: var(--gafa-color-text);
   font: inherit;
-  min-height: 46px;
-  padding: 0.75rem 0.9rem;
+  font-weight: 500;
+  min-height: 50px;
+  padding: 0.78rem 0.95rem;
+  width: 100%;
 }
 
-.gafa-sdk-state {
+.gafa-sdk-state,
+.gafa-sdk__state {
   border: 1px dashed var(--gafa-color-border);
   border-radius: var(--gafa-radius-md);
   color: var(--gafa-color-muted-text);
   padding: var(--gafa-space-4);
 }
 
-.gafa-sdk-state--error {
+.gafa-sdk-state--error,
+.gafa-sdk__state--error {
   border-color: var(--gafa-color-danger);
   color: var(--gafa-color-danger);
 }
@@ -155,7 +190,14 @@
   gap: var(--gafa-space-1);
 }
 
-.gafa-calendar-filter label {
+.gafa-calendar-filter,
+.gafa-calendar-filters label {
+  display: grid;
+  gap: var(--gafa-space-1);
+}
+
+.gafa-calendar-filter label,
+.gafa-calendar-filters label {
   color: var(--gafa-color-muted-text);
   font-size: 0.78rem;
   font-weight: 800;
@@ -163,7 +205,8 @@
   text-transform: uppercase;
 }
 
-.gafa-calendar-filter select {
+.gafa-calendar-filter select,
+.gafa-calendar-filters select {
   appearance: none;
   background: var(--gafa-color-surface);
   border: 1px solid var(--gafa-color-border);
@@ -208,7 +251,8 @@
   padding: var(--gafa-space-4);
 }
 
-.gafa-meeting-card__main {
+.gafa-meeting-card__main,
+.gafa-meeting-card__body {
   display: grid;
   gap: var(--gafa-space-2);
 }
@@ -282,5 +326,10 @@
 
   .gafa-meeting-card__aside {
     min-width: 160px;
+  }
+
+  .gafa-sdk-profile-grid,
+  .gafa-sdk__cards {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }

--- a/packages/react-sdk/src/sdk/widgets/widgets.css
+++ b/packages/react-sdk/src/sdk/widgets/widgets.css
@@ -124,6 +124,10 @@
   opacity: 0.5;
 }
 
+.gafa-sdk-button[aria-busy="true"] {
+  position: relative;
+}
+
 .gafa-sdk-button--secondary,
 .gafa-sdk-auth-tabs button[aria-pressed="false"] {
   background: color-mix(in srgb, var(--gafa-color-primary) 9%, var(--gafa-color-surface));
@@ -169,6 +173,16 @@
 .gafa-sdk__state--error {
   border-color: var(--gafa-color-danger);
   color: var(--gafa-color-danger);
+}
+
+.gafa-sdk-state--success {
+  border-color: var(--gafa-color-success);
+  color: var(--gafa-color-success);
+}
+
+.gafa-sdk-state--success {
+  border-color: var(--gafa-color-success);
+  color: var(--gafa-color-success);
 }
 
 .gafa-calendar {

--- a/packages/react-sdk/src/sdk/widgets/widgets.css
+++ b/packages/react-sdk/src/sdk/widgets/widgets.css
@@ -1,11 +1,34 @@
 .gafa-widget-card {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.88), rgba(255, 255, 255, 0.74)),
+    var(--gafa-color-surface);
+  border: 1px solid rgba(255, 255, 255, 0.78);
+  border-radius: var(--gafa-radius-xl);
+  box-shadow: var(--gafa-shadow-card);
   display: grid;
-  gap: var(--gafa-space-4);
+  gap: var(--gafa-space-5);
+  overflow: hidden;
+  padding: var(--gafa-space-5);
+  position: relative;
+}
+
+.gafa-widget-card::before {
+  background: radial-gradient(circle, color-mix(in srgb, var(--gafa-color-accent) 18%, transparent), transparent 66%);
+  content: "";
+  height: 180px;
+  opacity: 0.85;
+  pointer-events: none;
+  position: absolute;
+  right: -82px;
+  top: -98px;
+  width: 180px;
 }
 
 .gafa-widget-header {
   display: grid;
   gap: var(--gafa-space-3);
+  position: relative;
+  z-index: 1;
 }
 
 .gafa-widget-heading {
@@ -24,7 +47,7 @@
 .gafa-eyebrow,
 .gafa-sdk-label,
 .gafa-sdk__meta {
-  color: var(--gafa-color-primary);
+  color: var(--gafa-color-accent);
   font-size: 0.76rem;
   font-weight: 850;
   letter-spacing: 0.08em;
@@ -42,7 +65,7 @@
 }
 
 .gafa-widget-card h2 {
-  font-size: clamp(1.65rem, 8vw, 2.35rem);
+  font-size: clamp(1.8rem, 8vw, 2.65rem);
   line-height: 1.02;
 }
 
@@ -63,17 +86,19 @@
 }
 
 .gafa-sdk-panel,
+.gafa-sdk-card,
 .gafa-sdk__card {
-  background: color-mix(in srgb, var(--gafa-color-surface) 94%, white);
-  border: 1px solid color-mix(in srgb, var(--gafa-color-border) 70%, transparent);
+  background: rgba(255, 255, 255, 0.72);
+  border: 1px solid rgba(255, 255, 255, 0.78);
   border-radius: var(--gafa-radius-lg);
-  box-shadow: var(--gafa-shadow-card);
+  box-shadow: var(--gafa-shadow-soft);
   display: grid;
   gap: var(--gafa-space-3);
   padding: var(--gafa-space-4);
 }
 
 .gafa-sdk-profile-grid,
+.gafa-sdk-grid,
 .gafa-sdk__cards {
   display: grid;
   gap: var(--gafa-space-3);
@@ -119,6 +144,12 @@
   width: 100%;
 }
 
+.gafa-sdk-button:not(:disabled):active,
+.gafa-sdk-primary-button:not(:disabled):active,
+.gafa-sdk-auth-tabs button:not(:disabled):active {
+  transform: translateY(1px) scale(0.99);
+}
+
 .gafa-sdk-button:disabled {
   cursor: not-allowed;
   opacity: 0.5;
@@ -130,7 +161,7 @@
 
 .gafa-sdk-button--secondary,
 .gafa-sdk-auth-tabs button[aria-pressed="false"] {
-  background: color-mix(in srgb, var(--gafa-color-primary) 9%, var(--gafa-color-surface));
+  background: rgba(17, 24, 39, 0.07);
   color: var(--gafa-color-text);
 }
 
@@ -150,8 +181,8 @@
 .gafa-sdk-field input,
 .gafa-sdk-field select {
   appearance: none;
-  background: color-mix(in srgb, var(--gafa-color-surface) 92%, white);
-  border: 1px solid var(--gafa-color-border);
+  background: rgba(255, 255, 255, 0.82);
+  border: 1px solid rgba(17, 24, 39, 0.1);
   border-radius: var(--gafa-radius-md);
   color: var(--gafa-color-text);
   font: inherit;
@@ -161,9 +192,18 @@
   width: 100%;
 }
 
+.gafa-sdk-field input:focus,
+.gafa-sdk-field select:focus,
+.gafa-calendar-filters select:focus {
+  border-color: color-mix(in srgb, var(--gafa-color-accent) 70%, var(--gafa-color-primary));
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--gafa-color-accent) 15%, transparent);
+  outline: none;
+}
+
 .gafa-sdk-state,
 .gafa-sdk__state {
-  border: 1px dashed var(--gafa-color-border);
+  background: rgba(255, 255, 255, 0.66);
+  border: 1px dashed rgba(17, 24, 39, 0.14);
   border-radius: var(--gafa-radius-md);
   color: var(--gafa-color-muted-text);
   padding: var(--gafa-space-4);
@@ -180,19 +220,14 @@
   color: var(--gafa-color-success);
 }
 
-.gafa-sdk-state--success {
-  border-color: var(--gafa-color-success);
-  color: var(--gafa-color-success);
-}
-
 .gafa-calendar {
   display: grid;
   gap: var(--gafa-space-4);
 }
 
 .gafa-calendar-filters {
-  background: color-mix(in srgb, var(--gafa-color-primary) 5%, var(--gafa-color-surface));
-  border: 1px solid var(--gafa-color-border);
+  background: rgba(255, 255, 255, 0.64);
+  border: 1px solid rgba(255, 255, 255, 0.72);
   border-radius: var(--gafa-radius-lg);
   display: grid;
   gap: var(--gafa-space-3);
@@ -222,13 +257,16 @@
 .gafa-calendar-filter select,
 .gafa-calendar-filters select {
   appearance: none;
-  background: var(--gafa-color-surface);
-  border: 1px solid var(--gafa-color-border);
+  background:
+    linear-gradient(45deg, transparent 50%, var(--gafa-color-muted-text) 50%) right 1rem center / 7px 7px no-repeat,
+    linear-gradient(135deg, var(--gafa-color-muted-text) 50%, transparent 50%) right 0.72rem center / 7px 7px no-repeat,
+    rgba(255, 255, 255, 0.86);
+  border: 1px solid rgba(17, 24, 39, 0.1);
   border-radius: var(--gafa-radius-md);
   color: var(--gafa-color-text);
   font: inherit;
-  min-height: 46px;
-  padding: 0.75rem 0.9rem;
+  min-height: 50px;
+  padding: 0.75rem 2.35rem 0.75rem 0.9rem;
 }
 
 .gafa-calendar-summary {
@@ -244,7 +282,8 @@
 
 .gafa-day-group h3 {
   color: var(--gafa-color-text);
-  font-size: 1rem;
+  font-size: 0.98rem;
+  letter-spacing: -0.02em;
   margin: 0;
   text-transform: capitalize;
 }
@@ -256,10 +295,10 @@
 
 .gafa-meeting-card {
   align-items: stretch;
-  background: var(--gafa-color-surface);
-  border: 1px solid var(--gafa-color-border);
-  border-radius: var(--gafa-radius-lg);
-  box-shadow: var(--gafa-shadow-card);
+  background: rgba(255, 255, 255, 0.82);
+  border: 1px solid rgba(255, 255, 255, 0.82);
+  border-radius: var(--gafa-radius-xl);
+  box-shadow: var(--gafa-shadow-soft);
   display: grid;
   gap: var(--gafa-space-3);
   padding: var(--gafa-space-4);
@@ -272,7 +311,7 @@
 }
 
 .gafa-meeting-time {
-  color: var(--gafa-color-primary);
+  color: var(--gafa-color-accent);
   font-size: 0.9rem;
   font-weight: 900;
 }
@@ -315,8 +354,37 @@
   font-weight: 700;
 }
 
+.gafa-availability-pill {
+  align-items: center;
+  background: rgba(22, 163, 74, 0.1);
+  border-radius: var(--gafa-radius-pill);
+  color: var(--gafa-color-success);
+  display: inline-flex;
+  font-size: 0.82rem;
+  font-weight: 850;
+  justify-content: center;
+  min-height: 34px;
+  padding: 0.35rem 0.75rem;
+}
+
+.gafa-availability-pill--reserved {
+  background: rgba(17, 24, 39, 0.08);
+  color: var(--gafa-color-text);
+}
+
+.gafa-availability-pill--waitlist {
+  background: color-mix(in srgb, var(--gafa-color-accent) 14%, transparent);
+  color: var(--gafa-color-accent);
+}
+
+.gafa-availability-pill--sold-out {
+  background: color-mix(in srgb, var(--gafa-color-danger) 10%, transparent);
+  color: var(--gafa-color-danger);
+}
+
 .gafa-empty-state {
-  border: 1px dashed var(--gafa-color-border);
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px dashed rgba(17, 24, 39, 0.14);
   border-radius: var(--gafa-radius-lg);
   color: var(--gafa-color-muted-text);
   display: grid;
@@ -343,6 +411,7 @@
   }
 
   .gafa-sdk-profile-grid,
+  .gafa-sdk-grid,
   .gafa-sdk__cards {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }

--- a/packages/react-sdk/src/sdk/widgets/widgets.css
+++ b/packages/react-sdk/src/sdk/widgets/widgets.css
@@ -135,3 +135,152 @@
   border-color: var(--gafa-color-danger);
   color: var(--gafa-color-danger);
 }
+
+.gafa-calendar {
+  display: grid;
+  gap: var(--gafa-space-4);
+}
+
+.gafa-calendar-filters {
+  background: color-mix(in srgb, var(--gafa-color-primary) 5%, var(--gafa-color-surface));
+  border: 1px solid var(--gafa-color-border);
+  border-radius: var(--gafa-radius-lg);
+  display: grid;
+  gap: var(--gafa-space-3);
+  padding: var(--gafa-space-3);
+}
+
+.gafa-calendar-filter {
+  display: grid;
+  gap: var(--gafa-space-1);
+}
+
+.gafa-calendar-filter label {
+  color: var(--gafa-color-muted-text);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.gafa-calendar-filter select {
+  appearance: none;
+  background: var(--gafa-color-surface);
+  border: 1px solid var(--gafa-color-border);
+  border-radius: var(--gafa-radius-md);
+  color: var(--gafa-color-text);
+  font: inherit;
+  min-height: 46px;
+  padding: 0.75rem 0.9rem;
+}
+
+.gafa-calendar-summary {
+  color: var(--gafa-color-muted-text);
+  font-size: 0.92rem;
+  margin: 0;
+}
+
+.gafa-day-group {
+  display: grid;
+  gap: var(--gafa-space-2);
+}
+
+.gafa-day-group h3 {
+  color: var(--gafa-color-text);
+  font-size: 1rem;
+  margin: 0;
+  text-transform: capitalize;
+}
+
+.gafa-meeting-list {
+  display: grid;
+  gap: var(--gafa-space-3);
+}
+
+.gafa-meeting-card {
+  align-items: stretch;
+  background: var(--gafa-color-surface);
+  border: 1px solid var(--gafa-color-border);
+  border-radius: var(--gafa-radius-lg);
+  box-shadow: var(--gafa-shadow-card);
+  display: grid;
+  gap: var(--gafa-space-3);
+  padding: var(--gafa-space-4);
+}
+
+.gafa-meeting-card__main {
+  display: grid;
+  gap: var(--gafa-space-2);
+}
+
+.gafa-meeting-time {
+  color: var(--gafa-color-primary);
+  font-size: 0.9rem;
+  font-weight: 900;
+}
+
+.gafa-meeting-card h4 {
+  color: var(--gafa-color-text);
+  font-size: 1.08rem;
+  margin: 0;
+}
+
+.gafa-meeting-card p {
+  color: var(--gafa-color-muted-text);
+  margin: 0;
+}
+
+.gafa-meeting-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--gafa-space-2);
+}
+
+.gafa-meeting-chip {
+  background: color-mix(in srgb, var(--gafa-color-primary) 9%, transparent);
+  border-radius: var(--gafa-radius-pill);
+  color: var(--gafa-color-primary);
+  font-size: 0.78rem;
+  font-weight: 800;
+  padding: 0.3rem 0.65rem;
+}
+
+.gafa-meeting-card__aside {
+  align-items: stretch;
+  display: grid;
+  gap: var(--gafa-space-2);
+}
+
+.gafa-availability {
+  color: var(--gafa-color-muted-text);
+  font-size: 0.88rem;
+  font-weight: 700;
+}
+
+.gafa-empty-state {
+  border: 1px dashed var(--gafa-color-border);
+  border-radius: var(--gafa-radius-lg);
+  color: var(--gafa-color-muted-text);
+  display: grid;
+  gap: var(--gafa-space-1);
+  padding: var(--gafa-space-4);
+}
+
+.gafa-empty-state strong {
+  color: var(--gafa-color-text);
+}
+
+@media (min-width: 720px) {
+  .gafa-calendar-filters {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .gafa-meeting-card {
+    align-items: center;
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  .gafa-meeting-card__aside {
+    min-width: 160px;
+  }
+}

--- a/packages/react-sdk/tsconfig.json
+++ b/packages/react-sdk/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "declarationDir": "dist/types"
+  },
+  "include": ["src", "vite.config.ts", "vitest.config.ts"],
+  "references": []
+}

--- a/packages/react-sdk/vite.config.ts
+++ b/packages/react-sdk/vite.config.ts
@@ -3,6 +3,9 @@ import react from "@vitejs/plugin-react";
 
 export default defineConfig({
   plugins: [react()],
+  server: {
+    allowedHosts: true,
+  },
   build: {
     lib: {
       entry: "src/sdk/index.ts",

--- a/packages/react-sdk/vite.config.ts
+++ b/packages/react-sdk/vite.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    lib: {
+      entry: "src/sdk/index.ts",
+      name: "GafaThemeReactSdk",
+      fileName: "gafa-theme-react-sdk",
+      formats: ["es", "umd"],
+    },
+    rollupOptions: {
+      external: ["react", "react-dom", "react-dom/client"],
+      output: {
+        globals: {
+          react: "React",
+          "react-dom": "ReactDOM",
+          "react-dom/client": "ReactDOM",
+        },
+      },
+    },
+  },
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a parallel `packages/react-sdk` package using Vite, TypeScript, React 19-compatible peer setup, TanStack Query, Zustand, and Zod.
- Introduce the new public runtime API: `createGafaSdk`, programmatic mounts, and `bootstrapLegacyWidgets` for existing `data-gf-theme` shortcodes.
- Add validated legacy config parsing, brand theme tokens/CSS variables, a mock client, and a first legacy `GafaFitSDK` adapter seam.
- Build the first functional calendar widget with brand/location/service/staff filters, meeting range loading, local filtering, grouped day sections, availability states, and reservation CTAs.
- Connect the calendar `Reservar` CTA to the client checkout contract and the legacy `GafaFitSDK.GetCreateReservationForm` / `fancy` flow.
- Add a reservation preview modal/drawer that shows class details, availability, expected login/credit/payment steps, and the continue-reservation CTA for demo review.
- Improve the mobile preview design with a more polished landing, card system, form styling, meeting cards, catalog cards, and profile panels.
- Fix the Vite preview entry so the mobile demo mounts the React SDK widgets instead of leaving static legacy HTML.
- Allow external dev-server hosts so temporary mobile preview tunnels can reach the React SDK demo.
- Add root npm scripts to build/dev/typecheck the new SDK without changing the legacy Webpack SDK.

## Verification
- `npm run react-sdk:typecheck`
- `npm run react-sdk:build`
- Verified Cloudflare tunnel responds with `HTTP/2 200` for the Vite preview.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-741cc4c6-ac85-4635-a285-8e7459076468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-741cc4c6-ac85-4635-a285-8e7459076468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

