### PR TITLE
Set up Cursor Cloud dev environment (AGENTS.md + notes)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### What this is
+`GFtheme` is a **frontend-only** bundle: React 16 + webpack 4 + Babel 6. It renders theme
+components (login/register, calendars, combo/membership/service lists, purchase buttons) into
+HTML containers marked with `data-gf-theme="..."`. There is no backend, no database, and no
+automated test suite in this repo. Standard scripts live in `package.json` (`dev`, `watch`,
+`build`, `start`).
+
+### Running the dev server
+- Do NOT use `npm start` in a headless VM: it passes `--open`, which tries to launch a browser
+  and is unnecessary here. Instead run the dev server directly:
+  `npx webpack-dev-server --mode development --hot --host 0.0.0.0 --port 8080`
+  Then open `http://localhost:8080/`. Webpack live-reload/HMR is enabled and works.
+- `npm run build` (webpack production) succeeds on the installed Node (v22), despite the old
+  webpack 4 toolchain — no `--openssl-legacy-provider` workaround is needed.
+
+### External backend dependency (expected console errors)
+- The app requires a global `GafaFitSDK`, loaded via a `<script src=".../sdk/dist/main.js">` tag
+  in `src/index.html`. That tag currently points at `http://buq-kinsta.local/` (a non-resolvable
+  host). Without a reachable GAFAfit backend **and** valid API credentials
+  (`GAFA_FIT_URL`, `COMPANY_ID`, `API_CLIENT`, `API_SECRET`, captcha keys) in the
+  `data-gf-options` JSON block of `src/index.html`, the data-driven React components will not
+  populate. The browser console will show `GafaFitSDK is not defined` and
+  `ERR_NAME_NOT_RESOLVED`. This is expected in an isolated VM and is NOT an environment bug — the
+  static theme HTML (header, red "Compra ..." buttons, calendar container) still renders fine.
+
+### Files / gotchas
+- `src/index.html` is gitignored but present on disk; it is the webpack HTML template and the
+  place to edit API options / the SDK `<script>` URL for local testing.
+- `dist/main.min.js` IS tracked in git and `npm run build` overwrites it. Revert it
+  (`git checkout -- dist/main.min.js`) if you only built to test and don't intend to commit a
+  new bundle.
+- There is no linter configured, and `npm test` is a placeholder that just errors — do not treat
+  its failure as a real test failure.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for this webpack 4 / React 16 frontend theme bundle, and documents durable cloud-specific setup notes.

### What was verified
- `npm install` — installs cleanly (981 packages) on Node v22.
- `npm run build` — webpack production build succeeds (no OpenSSL legacy-provider workaround needed).
- Dev server — `npx webpack-dev-server --mode development --hot --host 0.0.0.0 --port 8080` compiles successfully and serves the theme page at `http://localhost:8080/` with HMR/live-reload enabled.
- Hello-world action — edited `src/index.html`, confirmed webpack recompiled and the browser live-reloaded to show the updated header (edit reverted afterward).

### Notes
- No code changes to the app; only `AGENTS.md` is added.
- The app needs an external `GafaFitSDK` global + a reachable GAFAfit backend and valid API credentials to populate data-driven components. In an isolated VM the SDK host (`http://buq-kinsta.local/`) is unresolvable, so those components stay empty and the console shows `GafaFitSDK is not defined` — expected, not an environment bug. Static theme HTML still renders.
- Suggested update script: `npm install`.

[webpack_dev_server_live_reload.mp4](https://cursor.com/agents/bc-2a980e91-5777-47bd-b2b6-860f67dd3f37/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwebpack_dev_server_live_reload.mp4)
[Initial page render](https://cursor.com/agents/bc-2a980e91-5777-47bd-b2b6-860f67dd3f37/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpage_initial_render.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a980e91-5777-47bd-b2b6-860f67dd3f37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a980e91-5777-47bd-b2b6-860f67dd3f37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

