### PR TITLE
perf(calendar): quitar delay artificial de 5s, cómputo muerto duplicado y memoizar filtros

### DIFF
--- a/src/components/calendar/Calendar.js
+++ b/src/components/calendar/Calendar.js
@@ -202,22 +202,26 @@ class Calendar extends React.Component {
         }
 
 
-        setTimeout(function () {
-            comp.setState({
-                locations: meetingsLocations,
-                brands: meetingsBrands,
-                rooms: meetingsRooms,
-                services: meetingsServices,
-                filter_staff: preFilterStaff,
-                filter_location: preFilterLocation,
-                filter_brand: preFilterBrand,
-                filter_service: preFilterService,
-                filter_room: preFilterRoom,
-                staff: meetingsStaff,
-                meetings: meetings,
-                is_mounted: true,
-            }, comp.initExternalButtons);
-        }, 5000);
+        // Antes había un setTimeout(..., 5000) aquí que forzaba una espera fija de
+        // 5 segundos antes de mostrar el calendario, sin importar si los datos ya
+        // estaban listos. Se quita: setState puede llamarse directo desde este
+        // callback (dispara por CalendarStorage.addSegmentedListener, no por un
+        // evento del DOM), no hay ninguna condición async pendiente que justifique
+        // el delay.
+        comp.setState({
+            locations: meetingsLocations,
+            brands: meetingsBrands,
+            rooms: meetingsRooms,
+            services: meetingsServices,
+            filter_staff: preFilterStaff,
+            filter_location: preFilterLocation,
+            filter_brand: preFilterBrand,
+            filter_service: preFilterService,
+            filter_room: preFilterRoom,
+            staff: meetingsStaff,
+            meetings: meetings,
+            is_mounted: true,
+        }, comp.initExternalButtons);
     }
 
     /**
@@ -286,6 +290,78 @@ class Calendar extends React.Component {
         }
     }
 
+    /**
+     * Aplica los 5 filtros (ubicacion/sala/servicio/marca/staff) sobre `meetings`.
+     * Antes esto se recalculaba desde cero en CADA render (incluyendo renders que
+     * no tienen nada que ver con los filtros ni con las meetings, como abrir/cerrar
+     * el modal de login). Se cachea el resultado y solo se vuelve a calcular si
+     * cambio el arreglo de meetings o alguno de los 5 valores de filtro.
+     */
+    getFilteredMeetings(meetings, filter_location, filter_room, filter_service, filter_brand, filter_staff) {
+        const cache = this._filteredMeetingsCache;
+
+        if (
+            cache &&
+            cache.meetings === meetings &&
+            cache.filter_location === filter_location &&
+            cache.filter_room === filter_room &&
+            cache.filter_service === filter_service &&
+            cache.filter_brand === filter_brand &&
+            cache.filter_staff === filter_staff
+        ) {
+            return cache.result;
+        }
+
+        let filtered = meetings;
+
+        if (filter_location && filter_location != 'Todos') {
+            filtered = filtered.filter(function (meeting) {
+                return meeting.location.name === filter_location
+            });
+        }
+
+        if (filter_room && filter_room != 'Todos') {
+            filtered = filtered.filter(function (meeting) {
+                return meeting.room.name === filter_room
+            });
+        }
+
+        if (filter_service && filter_service != 'Todos') {
+            filtered = filtered.filter(function (meeting) {
+                return meeting.service.name === filter_service ||
+                    (meeting.service.parent_id !== null && meeting.service.parent_service_recursive !== null && meeting.service.parent_service_recursive.name === filter_service);
+            });
+        }
+
+        if (filter_brand && filter_brand != 'Todos') {
+            filtered = filtered.filter(function (meeting) {
+                return meeting.location.brand.name === filter_brand
+            });
+        }
+
+        if (filter_staff && filter_staff != 'Todos') {
+            filtered = filtered.filter(function (meeting) {
+                let staff_name = meeting.staff.name + ' ' + (meeting.staff.hasOwnProperty('lastname') ? meeting.staff.lastname : '');
+                if (meeting.staff.hasOwnProperty('job') && meeting.staff.job !== null) {
+                    staff_name = meeting.staff.job;
+                }
+                return staff_name === filter_staff
+            });
+        }
+
+        this._filteredMeetingsCache = {
+            meetings,
+            filter_location,
+            filter_room,
+            filter_service,
+            filter_brand,
+            filter_staff,
+            result: filtered,
+        };
+
+        return filtered;
+    }
+
     render() {
         let {
             is_mounted,
@@ -314,40 +390,7 @@ class Calendar extends React.Component {
             width: widthDimension + 'px',
         };
 
-        if (filter_location && filter_location != 'Todos') {
-            meetings = meetings.filter(function (meeting) {
-                return meeting.location.name === filter_location
-            });
-        }
-
-        if (filter_room && filter_room != 'Todos') {
-            meetings = meetings.filter(function (meeting) {
-                return meeting.room.name === filter_room
-            });
-        }
-
-        if (filter_service && filter_service != 'Todos') {
-            meetings = meetings.filter(function (meeting) {
-                return meeting.service.name === filter_service ||
-                    (meeting.service.parent_id !== null && meeting.service.parent_service_recursive !== null && meeting.service.parent_service_recursive.name === filter_service);
-            });
-        }
-
-        if (filter_brand && filter_brand != 'Todos') {
-            meetings = meetings.filter(function (meeting) {
-                return meeting.location.brand.name === filter_brand
-            });
-        }
-
-        if (filter_staff && filter_staff != 'Todos') {
-            meetings = meetings.filter(function (meeting) {
-                let staff_name = meeting.staff.name + ' ' + (meeting.staff.hasOwnProperty('lastname') ? meeting.staff.lastname : '');
-                if (meeting.staff.hasOwnProperty('job') && meeting.staff.job !== null) {
-                    staff_name = meeting.staff.job;
-                }
-                return staff_name === filter_staff
-            });
-        }
+        meetings = this.getFilteredMeetings(meetings, filter_location, filter_room, filter_service, filter_brand, filter_staff);
 
         let head_class = '__head-' + (visualization === 'vertical' ? visualization : 'horizontal');
 

--- a/src/components/calendar/CalendarBody.js
+++ b/src/components/calendar/CalendarBody.js
@@ -283,82 +283,19 @@ class CalendarBody extends React.Component {
     }
 
     render() {
-        const {meetings, limit, login_initial} = this.props;
-        let {start, end, has_next, has_prev} = this.state;
+        // Nota: `meetings_to_show`/`dayList`/`beginsIn`/`settings`/`listItems` se
+        // calculaban aqui completos (recorriendo cada dia x cada meeting con
+        // moment) y luego se descartaban sin usarse: lo unico que realmente pinta
+        // los dias/meetings es `this.printCalendarColumns()` mas abajo, que vuelve
+        // a calcular exactamente lo mismo por su cuenta. Se quita el calculo
+        // duplicado; `printCalendarColumns()` sigue siendo la unica fuente.
+        let {has_next, has_prev} = this.state;
         let preC = 'GFSDK-c';
         let preE = 'GFSDK-e';
         let buttonClass = preE + '-buttons';
         let calendarClass = preC + '-Calendar';
-        let beginsIn, settings;
-        let meetings_to_show = [];
         let visualization = CalendarStorage.get('visualization');
         visualization = !!visualization ? visualization : 'horizontal';
-
-        if (start && end) {
-            meetings_to_show = this.getMeetingsToShow(this.props, start, end);
-
-            const dayList = meetings_to_show.map(function (day) {
-                return (
-                    moment(day.date).toDate()
-                );
-            });
-
-            if (meetings_to_show.length > 0) {
-                for (var i = 0; i < meetings_to_show.length; i++) {
-                    let day = meetings_to_show[i];
-                    if (day.meetings.length > 0) {
-                        beginsIn = i;
-                        break;
-                    }
-                }
-            }
-
-            settings = {
-                draggable: false,
-                infinite: false,
-                arrows: false,
-                adaptiveHeight: true,
-                initialSlide: beginsIn,
-                speed: 500,
-                slidesToScroll: 1,
-                slidesToShow: 1,
-                customPaging: function (i) {
-                    moment.locale(StringStore.getLanguage().toLowerCase());
-                    return (
-                        <a className={meetings_to_show[i].meetings.length === 0 ? 'empty-slide' : ''}>
-                            <div>
-                                <p className="this-date">{moment(dayList[i]).format('dd')}</p>
-                                <p className="this-number">{moment(dayList[i]).format('D')}</p>
-                            </div>
-                        </a>
-                    );
-                },
-                dots: true,
-                dotsClass: "slick-dots slick-thumb " + calendarClass + '__day-dots',
-                responsive: [
-                    {
-                        breakpoint: 992,
-                        settings: {
-                            slidesToShow: 1,
-                            slidesToScroll: 1,
-                        }
-                    },
-                ],
-            };
-        }
-
-        let listItems = meetings_to_show.map(
-            (day, index) => {
-                return <CalendarColumn
-                    key={`calendar-day--${index}`}
-                    index={index} day={day}
-                    limit={limit}
-                    openFancy={this.props.openFancy}
-                    closedFancy={this.props.closedFancy}
-                    login_initial={login_initial}
-                />
-            }
-        );
 
         return (
             <div className={calendarClass + '__body ' + visualization}>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Contexto
Reporte: el calendario legacy (`data-gf-theme="meetings-calendar"`) tarda hasta 30+ segundos en aparecer cuando hay muchos días/reuniones cargadas. Análisis completo (solo lectura) hecho antes de este PR.

Este PR incluye únicamente los 3 fixes de **menor riesgo y sin dependencias externas** de esa lista. Los demás (evitar recomputar por cada ubicación que responde, `key={uid()}` en las tarjetas de clase, acotar el rango de días pedido al backend, paralelizar `partial_loading`) quedan pendientes de confirmar con el equipo antes de tocarlos, porque requieren validar supuestos sobre los datos (unicidad de `meeting.id`, cuántas ubicaciones/marcas hay típicamente, si hay ambiente de staging para probar, etc.).

## Cambios

1. **`Calendar.js` — quitar el `setTimeout(..., 5000)`.** Antes de mostrar el calendario había una espera fija de 5 segundos sin ninguna condición async pendiente que la justifique (el callback ya se dispara de forma asíncrona vía `CalendarStorage.addSegmentedListener`, no por un evento del DOM). Se llama `setState` directo.
2. **`Calendar.js` — memoizar los 5 filtros (ubicación/sala/servicio/marca/staff).** Antes se recalculaban con `.filter()` encadenados en **cada render**, incluyendo renders que no tienen nada que ver con los filtros (por ejemplo abrir/cerrar el modal de login). Ahora se cachea el resultado en la instancia y solo se recalcula si cambia el arreglo `meetings` o alguno de los 5 valores de filtro.
3. **`CalendarBody.js` — quitar cómputo muerto y duplicado en `render()`.** `render()` calculaba `meetings_to_show`/`dayList`/`beginsIn`/`settings`/`listItems` completos (iterando cada día × cada reunión con `moment`) pero nunca los usaba: la única fuente real de lo que se pinta es `this.printCalendarColumns()`, que recalcula exactamente lo mismo por su cuenta. Se quita el cálculo duplicado; el comportamiento visual no cambia.

## Lo que NO se tocó (a propósito)
- No se tocó cómo/cuántas veces se piden los datos al backend.
- No se tocó el patrón `key={uid()}` en `CalendarMeeting` (necesita confirmar con el equipo si `meeting.id` es único en el rango visible antes de cambiarlo).
- `dist/main.min.js` **no se regeneró/commiteó** en este PR (solo código fuente) — antes de desplegar a producción hay que correr `npm run build` y commitear el bundle nuevo, siguiendo la convención existente del repo.

## Verificación hecha
- `npm run build` compila sin errores nuevos (mismos warnings de Sass/tamaño de bundle que ya existían antes de este cambio).
- Revisión manual línea por línea confirmando que ningún valor removido de `render()` se usaba fuera del bloque eliminado.

## Cómo probarlo / cómo cancelarlo
- Este PR se deja en **draft** y sin mergear a propósito. Pruébenlo en un ambiente de staging/dev apuntando a un sitio con muchas ubicaciones/días para confirmar la mejora real de tiempo de carga.
- Si algo se ve raro (filtros que no actualizan, calendario que no aparece), es señal de rollback: basta con **cerrar este PR sin mergear**, `master` sigue intacto.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-741cc4c6-ac85-4635-a285-8e7459076468?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-741cc4c6-ac85-4635-a285-8e7459076468&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

