### PR TITLE
perf(calendar): 4 fixes de rendimiento consolidados contra dev-SDK-webapp

### DIFF
--- a/src/components/GafaThemeSDK.js
+++ b/src/components/GafaThemeSDK.js
@@ -323,7 +323,7 @@ class GafaThemeSDK extends React.Component {
 
                 }
             } else {
-                GafaFitSDKWrapper.getMeetingsInLocation(location, start_string, end_string, function (result) {
+                let mergeMeetingsResult = function (result) {
                     result.forEach(function (meeting) {
                         meeting.location = location;
                         meetings.push(meeting);
@@ -331,7 +331,36 @@ class GafaThemeSDK extends React.Component {
                     CalendarStorage.set('meetings', meetings);
                     if (location_index === 0)
                         CalendarStorage.set('start_date', start_date);
-                });
+                };
+
+                // Antes se pedian TODOS los dias de location.calendar_days en una sola
+                // llamada (p.ej. 21 dias de golpe), aunque la vista inicial solo muestra
+                // 7. Eso hacia que el usuario esperara el payload completo (que puede ser
+                // de varios MB con muchas reuniones) antes de ver una sola clase.
+                //
+                // Ahora, si el rango es mayor a FIRST_CHUNK_DAYS, se piden 2 tramos EN
+                // PARALELO: la primera semana (para pintar rapido) y el resto del rango
+                // (para que "siguiente semana" siga funcionando exactamente igual que
+                // antes, sin cambiar esa logica). El resultado final acumulado en
+                // `meetings` es identico al de antes, solo que llega en 2 partes en vez
+                // de 1, y la primera parte llega mucho mas rapido.
+                const FIRST_CHUNK_DAYS = 7;
+                const totalDays = location.calendar_days || FIRST_CHUNK_DAYS;
+
+                if (totalDays > FIRST_CHUNK_DAYS) {
+                    let firstChunkEnd = new Date(start_date.getTime());
+                    firstChunkEnd.setDate(start_date.getDate() + (FIRST_CHUNK_DAYS - 1));
+                    let firstChunkEndString = `${firstChunkEnd.getFullYear()}-${firstChunkEnd.getMonth() + 1}-${firstChunkEnd.getDate()}`;
+
+                    let restStart = new Date(start_date.getTime());
+                    restStart.setDate(start_date.getDate() + FIRST_CHUNK_DAYS);
+                    let restStartString = `${restStart.getFullYear()}-${restStart.getMonth() + 1}-${restStart.getDate()}`;
+
+                    GafaFitSDKWrapper.getMeetingsInLocation(location, start_string, firstChunkEndString, mergeMeetingsResult);
+                    GafaFitSDKWrapper.getMeetingsInLocation(location, restStartString, end_string, mergeMeetingsResult);
+                } else {
+                    GafaFitSDKWrapper.getMeetingsInLocation(location, start_string, end_string, mergeMeetingsResult);
+                }
             }
 
         });

--- a/src/components/calendar/Calendar.js
+++ b/src/components/calendar/Calendar.js
@@ -16,6 +16,31 @@ import '../../styles/newlook/elements/GFSDK-e-meeting.scss';
 import '../../styles/newlook/elements/GFSDK-e-navigation.scss';
 import StringStore from "../utils/Strings/StringStore";
 
+/**
+ * Debounce simple sin dependencias externas. `GafaThemeSDK.renderMeetingsCalendar`
+ * puede llamar `CalendarStorage.set('meetings', ...)` varias veces seguidas (una
+ * por cada respuesta de red: por ubicacion, y ahora tambien por cada tramo del
+ * rango de fechas). Sin esto, el recalculo pesado de `setInitialValues` (que
+ * recorre TODAS las reuniones para armar los filtros de marca/ubicacion/sala/
+ * servicio/staff) corria una vez por cada una de esas respuestas. Con el
+ * debounce, solo corre una vez, cuando las respuestas dejan de llegar por
+ * `wait` ms.
+ */
+function debounce(fn, wait) {
+    let timeoutId = null;
+
+    function debounced(...args) {
+        clearTimeout(timeoutId);
+        timeoutId = setTimeout(() => fn.apply(this, args), wait);
+    }
+
+    debounced.cancel = function () {
+        clearTimeout(timeoutId);
+    };
+
+    return debounced;
+}
+
 class Calendar extends React.Component {
     constructor(props) {
         super(props);
@@ -38,13 +63,22 @@ class Calendar extends React.Component {
         };
 
         this.selectFilter = this.selectFilter.bind(this);
+        this.setInitialValues = this.setInitialValues.bind(this);
+        this.debouncedSetInitialValues = debounce(this.setInitialValues, 150);
+
         CalendarStorage.set('visualization', props.visualization);
         CalendarStorage.set('show_login', this.setShowLogin.bind(this));
         CalendarStorage.set('show_register', this.setShowRegister.bind(this));
         CalendarStorage.set('show_description', props.show_description);
         GlobalStorage.set('block_after_login', props.block_after_login);
         CalendarStorage.set('show_parent', props.show_parent);
-        CalendarStorage.addSegmentedListener(['meetings'], this.setInitialValues.bind(this));
+        CalendarStorage.addSegmentedListener(['meetings'], this.debouncedSetInitialValues);
+    }
+
+    componentWillUnmount() {
+        if (this.debouncedSetInitialValues && this.debouncedSetInitialValues.cancel) {
+            this.debouncedSetInitialValues.cancel();
+        }
     }
 
 

--- a/src/components/calendar/Calendar.js
+++ b/src/components/calendar/Calendar.js
@@ -202,22 +202,26 @@ class Calendar extends React.Component {
         }
 
 
-        setTimeout(function () {
-            comp.setState({
-                locations: meetingsLocations,
-                brands: meetingsBrands,
-                rooms: meetingsRooms,
-                services: meetingsServices,
-                filter_staff: preFilterStaff,
-                filter_location: preFilterLocation,
-                filter_brand: preFilterBrand,
-                filter_service: preFilterService,
-                filter_room: preFilterRoom,
-                staff: meetingsStaff,
-                meetings: meetings,
-                is_mounted: true,
-            }, comp.initExternalButtons);
-        }, 5000);
+        // Antes había un setTimeout(..., 5000) aquí que forzaba una espera fija de
+        // 5 segundos antes de mostrar el calendario, sin importar si los datos ya
+        // estaban listos. Se quita: setState puede llamarse directo desde este
+        // callback (dispara por CalendarStorage.addSegmentedListener, no por un
+        // evento del DOM), no hay ninguna condición async pendiente que justifique
+        // el delay.
+        comp.setState({
+            locations: meetingsLocations,
+            brands: meetingsBrands,
+            rooms: meetingsRooms,
+            services: meetingsServices,
+            filter_staff: preFilterStaff,
+            filter_location: preFilterLocation,
+            filter_brand: preFilterBrand,
+            filter_service: preFilterService,
+            filter_room: preFilterRoom,
+            staff: meetingsStaff,
+            meetings: meetings,
+            is_mounted: true,
+        }, comp.initExternalButtons);
     }
 
     /**
@@ -286,6 +290,78 @@ class Calendar extends React.Component {
         }
     }
 
+    /**
+     * Aplica los 5 filtros (ubicacion/sala/servicio/marca/staff) sobre `meetings`.
+     * Antes esto se recalculaba desde cero en CADA render (incluyendo renders que
+     * no tienen nada que ver con los filtros ni con las meetings, como abrir/cerrar
+     * el modal de login). Se cachea el resultado y solo se vuelve a calcular si
+     * cambio el arreglo de meetings o alguno de los 5 valores de filtro.
+     */
+    getFilteredMeetings(meetings, filter_location, filter_room, filter_service, filter_brand, filter_staff) {
+        const cache = this._filteredMeetingsCache;
+
+        if (
+            cache &&
+            cache.meetings === meetings &&
+            cache.filter_location === filter_location &&
+            cache.filter_room === filter_room &&
+            cache.filter_service === filter_service &&
+            cache.filter_brand === filter_brand &&
+            cache.filter_staff === filter_staff
+        ) {
+            return cache.result;
+        }
+
+        let filtered = meetings;
+
+        if (filter_location && filter_location != 'Todos') {
+            filtered = filtered.filter(function (meeting) {
+                return meeting.location.name === filter_location
+            });
+        }
+
+        if (filter_room && filter_room != 'Todos') {
+            filtered = filtered.filter(function (meeting) {
+                return meeting.room.name === filter_room
+            });
+        }
+
+        if (filter_service && filter_service != 'Todos') {
+            filtered = filtered.filter(function (meeting) {
+                return meeting.service.name === filter_service ||
+                    (meeting.service.parent_id !== null && meeting.service.parent_service_recursive !== null && meeting.service.parent_service_recursive.name === filter_service);
+            });
+        }
+
+        if (filter_brand && filter_brand != 'Todos') {
+            filtered = filtered.filter(function (meeting) {
+                return meeting.location.brand.name === filter_brand
+            });
+        }
+
+        if (filter_staff && filter_staff != 'Todos') {
+            filtered = filtered.filter(function (meeting) {
+                let staff_name = meeting.staff.name + ' ' + (meeting.staff.hasOwnProperty('lastname') ? meeting.staff.lastname : '');
+                if (meeting.staff.hasOwnProperty('job') && meeting.staff.job !== null) {
+                    staff_name = meeting.staff.job;
+                }
+                return staff_name === filter_staff
+            });
+        }
+
+        this._filteredMeetingsCache = {
+            meetings,
+            filter_location,
+            filter_room,
+            filter_service,
+            filter_brand,
+            filter_staff,
+            result: filtered,
+        };
+
+        return filtered;
+    }
+
     render() {
         let {
             is_mounted,
@@ -314,40 +390,7 @@ class Calendar extends React.Component {
             width: widthDimension + 'px',
         };
 
-        if (filter_location && filter_location != 'Todos') {
-            meetings = meetings.filter(function (meeting) {
-                return meeting.location.name === filter_location
-            });
-        }
-
-        if (filter_room && filter_room != 'Todos') {
-            meetings = meetings.filter(function (meeting) {
-                return meeting.room.name === filter_room
-            });
-        }
-
-        if (filter_service && filter_service != 'Todos') {
-            meetings = meetings.filter(function (meeting) {
-                return meeting.service.name === filter_service ||
-                    (meeting.service.parent_id !== null && meeting.service.parent_service_recursive !== null && meeting.service.parent_service_recursive.name === filter_service);
-            });
-        }
-
-        if (filter_brand && filter_brand != 'Todos') {
-            meetings = meetings.filter(function (meeting) {
-                return meeting.location.brand.name === filter_brand
-            });
-        }
-
-        if (filter_staff && filter_staff != 'Todos') {
-            meetings = meetings.filter(function (meeting) {
-                let staff_name = meeting.staff.name + ' ' + (meeting.staff.hasOwnProperty('lastname') ? meeting.staff.lastname : '');
-                if (meeting.staff.hasOwnProperty('job') && meeting.staff.job !== null) {
-                    staff_name = meeting.staff.job;
-                }
-                return staff_name === filter_staff
-            });
-        }
+        meetings = this.getFilteredMeetings(meetings, filter_location, filter_room, filter_service, filter_brand, filter_staff);
 
         let head_class = '__head-' + (visualization === 'vertical' ? visualization : 'horizontal');
 

--- a/src/components/calendar/CalendarBody.js
+++ b/src/components/calendar/CalendarBody.js
@@ -283,82 +283,19 @@ class CalendarBody extends React.Component {
     }
 
     render() {
-        const {meetings, limit, login_initial} = this.props;
-        let {start, end, has_next, has_prev} = this.state;
+        // Nota: `meetings_to_show`/`dayList`/`beginsIn`/`settings`/`listItems` se
+        // calculaban aqui completos (recorriendo cada dia x cada meeting con
+        // moment) y luego se descartaban sin usarse: lo unico que realmente pinta
+        // los dias/meetings es `this.printCalendarColumns()` mas abajo, que vuelve
+        // a calcular exactamente lo mismo por su cuenta. Se quita el calculo
+        // duplicado; `printCalendarColumns()` sigue siendo la unica fuente.
+        let {has_next, has_prev} = this.state;
         let preC = 'GFSDK-c';
         let preE = 'GFSDK-e';
         let buttonClass = preE + '-buttons';
         let calendarClass = preC + '-Calendar';
-        let beginsIn, settings;
-        let meetings_to_show = [];
         let visualization = CalendarStorage.get('visualization');
         visualization = !!visualization ? visualization : 'horizontal';
-
-        if (start && end) {
-            meetings_to_show = this.getMeetingsToShow(this.props, start, end);
-
-            const dayList = meetings_to_show.map(function (day) {
-                return (
-                    moment(day.date).toDate()
-                );
-            });
-
-            if (meetings_to_show.length > 0) {
-                for (var i = 0; i < meetings_to_show.length; i++) {
-                    let day = meetings_to_show[i];
-                    if (day.meetings.length > 0) {
-                        beginsIn = i;
-                        break;
-                    }
-                }
-            }
-
-            settings = {
-                draggable: false,
-                infinite: false,
-                arrows: false,
-                adaptiveHeight: true,
-                initialSlide: beginsIn,
-                speed: 500,
-                slidesToScroll: 1,
-                slidesToShow: 1,
-                customPaging: function (i) {
-                    moment.locale(StringStore.getLanguage().toLowerCase());
-                    return (
-                        <a className={meetings_to_show[i].meetings.length === 0 ? 'empty-slide' : ''}>
-                            <div>
-                                <p className="this-date">{moment(dayList[i]).format('dd')}</p>
-                                <p className="this-number">{moment(dayList[i]).format('D')}</p>
-                            </div>
-                        </a>
-                    );
-                },
-                dots: true,
-                dotsClass: "slick-dots slick-thumb " + calendarClass + '__day-dots',
-                responsive: [
-                    {
-                        breakpoint: 992,
-                        settings: {
-                            slidesToShow: 1,
-                            slidesToScroll: 1,
-                        }
-                    },
-                ],
-            };
-        }
-
-        let listItems = meetings_to_show.map(
-            (day, index) => {
-                return <CalendarColumn
-                    key={`calendar-day--${index}`}
-                    index={index} day={day}
-                    limit={limit}
-                    openFancy={this.props.openFancy}
-                    closedFancy={this.props.closedFancy}
-                    login_initial={login_initial}
-                />
-            }
-        );
 
         return (
             <div className={calendarClass + '__body ' + visualization}>

--- a/src/components/calendar/CalendarColumn.js
+++ b/src/components/calendar/CalendarColumn.js
@@ -4,7 +4,6 @@ import React from "react";
 import CalendarMeeting from "./CalendarMeeting";
 import moment from "moment";
 import 'moment/locale/es';
-import uid from 'uid';
 
 class CalendarColumn extends React.Component {
     constructor(props) {
@@ -42,12 +41,17 @@ class CalendarColumn extends React.Component {
       let today = new Date();
       let date = today.getFullYear() + '-' + (today.getMonth() + 1) + '-' + today.getDate();
 
+      // `meeting.id` es unico en toda la tabla (confirmado con el equipo de backend:
+      // no se repite ni entre reuniones recurrentes ni entre companies). Antes se
+      // usaba un `uid()` aleatorio ademas del id, lo que generaba una key NUEVA en
+      // cada render y forzaba a React a destruir y volver a montar cada tarjeta de
+      // clase en cada actualizacion, en vez de reutilizar el DOM existente.
       if (limit) {
          listItems = activeClass.slice(0, limit).map((meeting) => {
                if (meeting) {
                   return(  
                      <CalendarMeeting 
-                        key={`column-day--${uid()}--meeting--${meeting.id}`} 
+                        key={`column-day--meeting--${meeting.id}`} 
                         meeting={meeting} day={day} 
                         alignment={alignment}
                         openFancy = {this.props.openFancy}
@@ -62,7 +66,7 @@ class CalendarColumn extends React.Component {
             if (meeting) {
                return (
                   <CalendarMeeting 
-                     key={`column-day--${uid()}--meeting--${meeting.id}`} 
+                     key={`column-day--meeting--${meeting.id}`} 
                      meeting={meeting} 
                      day={day} 
                      alignment={alignment}

--- a/src/components/calendar/vertical/MonthCalendarBody.js
+++ b/src/components/calendar/vertical/MonthCalendarBody.js
@@ -3,7 +3,6 @@
 import React, { useState } from 'react';
 import moment from "moment";
 import CalendarMeeting from "../CalendarMeeting";
-import uid from "uid";
 import Slider from "react-slick";
 import Calendar from "react-calendar"; // Importar react-calendar
 import 'react-calendar/dist/Calendar.css'; // Importar estilos predeterminados
@@ -123,11 +122,14 @@ export default class VerticalCalendarBody extends React.Component {
                 activeClass = activeClass.slice(0, limit);
             }
 
+            // `meeting.id` es unico en toda la tabla (confirmado con backend), asi que
+            // sirve solo como key sin necesidad de un `uid()` aleatorio que forzaba a
+            // React a remontar cada tarjeta en cada actualizacion.
             column_days = activeClass.map((meeting) => {
                 if (meeting) {
                     return (
                         <CalendarMeeting
-                            key={`column-day--${uid()}--meeting--${meeting.id}`}
+                            key={`column-day--meeting--${meeting.id}`}
                             meeting={meeting}
                             day={day}
                             openFancy={openFancy}

--- a/src/components/calendar/vertical/VerticalCalendarBody.js
+++ b/src/components/calendar/vertical/VerticalCalendarBody.js
@@ -3,7 +3,6 @@
 import React from 'react'
 import moment from "moment";
 import CalendarMeeting from "../CalendarMeeting";
-import uid from "uid";
 import Slider from "react-slick";
 import StringStore from "../../utils/Strings/StringStore";
 
@@ -77,11 +76,14 @@ export default class VerticalCalendarBody extends React.Component {
                 activeClass.slice(0, limit)
             }
 
+            // `meeting.id` es unico en toda la tabla (confirmado con backend), asi que
+            // sirve solo como key sin necesidad de un `uid()` aleatorio que forzaba a
+            // React a remontar cada tarjeta en cada actualizacion.
             column_days = activeClass.map((meeting) => {
                 if (meeting) {
                     return (
                         <CalendarMeeting
-                            key={`column-day--${uid()}--meeting--${meeting.id}`}
+                            key={`column-day--meeting--${meeting.id}`}
                             meeting={meeting}
                             day={day}
                             openFancy={openFancy}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Contexto
Argel confirmó que el destino real para probar y desplegar estos fixes es **`dev-SDK-webapp`** (no `master`), con bundle propio en `https://buq-sdk-dev.azurewebsites.net/dist/main.min.js`. Este PR **reemplaza a [#193](https://github.com/GafaMX/GFtheme/pull/193) y [#194](https://github.com/GafaMX/GFtheme/pull/194)** (que estaban contra `master`), aplicando exactamente los mismos cambios (cherry-pick limpio, sin conflictos — el módulo de calendario es idéntico entre `master` y `dev-SDK-webapp`) más un fix nuevo que Argel desbloqueó con sus respuestas.

## Los 4 fixes

1. **Quitar el `setTimeout(..., 5000)` fijo** antes de mostrar el calendario (ya probado por Argel en ambiente de prueba: "funciona todo bien, horizontal/vertical/mensual").
2. **Quitar cómputo muerto y duplicado** en `CalendarBody.render()`.
3. **Memoizar los 5 filtros** (marca/ubicación/sala/servicio/staff) para que no se recalculen en cada render.
4. **Carga progresiva del rango de fechas**: en vez de pedir todo `calendar_days` de una ubicación en una sola llamada (con Bunker Indoor Golf: 21 días = 6.3s y 826 KB por ubicación), se piden 2 tramos en paralelo (primera semana + resto), con debounce del recálculo pesado para que no corra el doble de veces.
5. **`key={meeting.id}` en vez de `uid()` aleatorio** en las tarjetas de clase (`CalendarColumn`, `VerticalCalendarBody`, `MonthCalendarBody`). Antes la key cambiaba en cada render, forzando a React a destruir y remontar TODAS las tarjetas visibles en cada actualización. Argel confirmó que `meeting.id` es único en toda la tabla, sin importar si son recurrentes o de otra company — ya no hay riesgo de colisión.

## Ya validado por Argel (en #193)
> "Revisé en ambiente de prueba y parece estar funcionando todo bien. Tanto la vista horizontal, como la vertical y la mensual. Noté que cuando se tarda mucho la carga no se activa el botón de siguiente semana al terminar de cargar las clases, pero eso se resolvería con los cambios de cargas más cortas que sugeriste." — el punto que menciona ya está incluido aquí (fix #4).

## Lo que NO se tocó (a propósito, para más adelante)
- La paginación real por semana (pedir datos nuevos solo al hacer clic en "siguiente semana", con caché acotado en memoria) — Argel confirmó que es viable (punto A de sus respuestas), pero es un cambio más grande que toca la lógica de navegación. Se deja para una siguiente iteración si hace falta más ganancia después de medir el impacto de estos 4 fixes.
- Los ~600 registros por ubicación en 21 días son volumen real de negocio (simuladores de golf con slots de 30 min todo el día), no un bug — no hay nada que "arreglar" ahí del lado del cliente más allá de pedir menos días de golpe (ya cubierto por el fix #4).

## Verificación hecha
- `npm run build` compila sin errores nuevos.
- Cherry-pick sin conflictos desde las ramas de #193/#194 (contenido idéntico entre `master` y `dev-SDK-webapp` en estos archivos).
- Búsqueda confirmando que no queda ningún uso de `uid()` en el código tras el fix #5.
- `dist/main.min.js` no se regeneró/commiteó — falta correr `npm run build` y commitear antes de publicar en `buq-sdk-dev.azurewebsites.net`.

## Próximos pasos
- Probar en el ambiente de prueba real (`dev-SDK-webapp` + bundle de `buq-sdk-dev.azurewebsites.net`) apuntando a un sitio como Bunker para confirmar la mejora real de tiempo.
- Si todo bien: cerrar #193 y #194 (quedan reemplazados por este).
- Decidir si vale la pena la paginación real por semana como siguiente iteración.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-741cc4c6-ac85-4635-a285-8e7459076468?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-741cc4c6-ac85-4635-a285-8e7459076468&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

