### PR TITLE
feat(calendar): skeleton cards con shimmer, indicador de carga en segundo plano y fade-in

### DIFF
--- a/src/components/GafaThemeSDK.js
+++ b/src/components/GafaThemeSDK.js
@@ -51,6 +51,23 @@ class GafaThemeSDK extends React.Component {
         ReactDOM.render(React.createElement(elementToRender, props), domContainer);
     }
 
+    /**
+     * Lleva la cuenta de cuantas peticiones de reuniones siguen pendientes
+     * (una por cada tramo de fechas x ubicacion/sala que dispara
+     * renderMeetingsCalendar). El calendario usa esto para mostrar un
+     * indicador chico de "cargando mas dias..." mientras la primera semana ya
+     * se ve real pero el resto sigue en camino.
+     */
+    static incrementPendingMeetingRequests(by = 1) {
+        let current = CalendarStorage.get('pendingMeetingRequests') || 0;
+        CalendarStorage.set('pendingMeetingRequests', current + by);
+    }
+
+    static decrementPendingMeetingRequests() {
+        let current = CalendarStorage.get('pendingMeetingRequests') || 0;
+        CalendarStorage.set('pendingMeetingRequests', Math.max(0, current - 1));
+    }
+
     //  static renderStaffListWithoutPagination(selector) {
     //    let domContainers = document.querySelectorAll(selector);
     //    if (domContainers.length > 0) {
@@ -301,6 +318,7 @@ class GafaThemeSDK extends React.Component {
                 });
                 if (location_rooms.length) {
                     let index = 0;
+                    GafaThemeSDK.incrementPendingMeetingRequests();
                     let process_room_meetings = function (result) {
                         result.forEach(function (meeting) {
                             meeting.location = location;
@@ -309,11 +327,13 @@ class GafaThemeSDK extends React.Component {
                         let next_room = location_rooms[index + 1];
                         if (!!next_room) {
                             index++;
+                            GafaThemeSDK.incrementPendingMeetingRequests();
                             GafaFitSDKWrapper.getMeetingsInRoom(next_room.id, location.id, start_string, end_string, process_room_meetings);
                         } else {
                             CalendarStorage.set('meetings', meetings);
                             CalendarStorage.set('start_date', start_date);
                         }
+                        GafaThemeSDK.decrementPendingMeetingRequests();
                     };
 
                     let room = location_rooms[index];
@@ -331,6 +351,7 @@ class GafaThemeSDK extends React.Component {
                     CalendarStorage.set('meetings', meetings);
                     if (location_index === 0)
                         CalendarStorage.set('start_date', start_date);
+                    GafaThemeSDK.decrementPendingMeetingRequests();
                 };
 
                 // Antes se pedian TODOS los dias de location.calendar_days en una sola
@@ -356,9 +377,11 @@ class GafaThemeSDK extends React.Component {
                     restStart.setDate(start_date.getDate() + FIRST_CHUNK_DAYS);
                     let restStartString = `${restStart.getFullYear()}-${restStart.getMonth() + 1}-${restStart.getDate()}`;
 
+                    GafaThemeSDK.incrementPendingMeetingRequests(2);
                     GafaFitSDKWrapper.getMeetingsInLocation(location, start_string, firstChunkEndString, mergeMeetingsResult);
                     GafaFitSDKWrapper.getMeetingsInLocation(location, restStartString, end_string, mergeMeetingsResult);
                 } else {
+                    GafaThemeSDK.incrementPendingMeetingRequests();
                     GafaFitSDKWrapper.getMeetingsInLocation(location, start_string, end_string, mergeMeetingsResult);
                 }
             }

--- a/src/components/calendar/Calendar.js
+++ b/src/components/calendar/Calendar.js
@@ -8,10 +8,11 @@ import LoginRegister from "../menu/LoginRegister";
 
 import IconSelectDownArrow from "../utils/Icons/IconSelectDownArrow";
 
-import Loading from '../common/Loading';
+import CalendarSkeleton from './CalendarSkeleton';
 // Estilos
 import '../../styles/newlook/components/GFSDK-c-Calendar.scss';
 import '../../styles/newlook/components/GFSDK-c-Filter.scss';
+import '../../styles/newlook/components/GFSDK-c-CalendarSkeleton.scss';
 import '../../styles/newlook/elements/GFSDK-e-meeting.scss';
 import '../../styles/newlook/elements/GFSDK-e-navigation.scss';
 import StringStore from "../utils/Strings/StringStore";
@@ -60,11 +61,13 @@ class Calendar extends React.Component {
             filter_location: "Todos",
             locations: [],
             is_mounted: false,
+            isLoadingMore: false,
         };
 
         this.selectFilter = this.selectFilter.bind(this);
         this.setInitialValues = this.setInitialValues.bind(this);
         this.debouncedSetInitialValues = debounce(this.setInitialValues, 150);
+        this.updateIsLoadingMore = this.updateIsLoadingMore.bind(this);
 
         CalendarStorage.set('visualization', props.visualization);
         CalendarStorage.set('show_login', this.setShowLogin.bind(this));
@@ -73,12 +76,22 @@ class Calendar extends React.Component {
         GlobalStorage.set('block_after_login', props.block_after_login);
         CalendarStorage.set('show_parent', props.show_parent);
         CalendarStorage.addSegmentedListener(['meetings'], this.debouncedSetInitialValues);
+        // La primera semana ya llega rapido y se muestra real; mientras el
+        // resto del rango sigue llegando en segundo plano, se muestra un
+        // indicador chico y discreto en vez de dejar al usuario sin ninguna
+        // senal de que todavia hay mas dias por cargar.
+        CalendarStorage.addSegmentedListener(['pendingMeetingRequests'], this.updateIsLoadingMore);
     }
 
     componentWillUnmount() {
         if (this.debouncedSetInitialValues && this.debouncedSetInitialValues.cancel) {
             this.debouncedSetInitialValues.cancel();
         }
+    }
+
+    updateIsLoadingMore() {
+        let pending = CalendarStorage.get('pendingMeetingRequests') || 0;
+        this.setState({isLoadingMore: pending > 0});
     }
 
 
@@ -399,6 +412,7 @@ class Calendar extends React.Component {
     render() {
         let {
             is_mounted,
+            isLoadingMore,
             meetings,
             locations,
             filter_location,
@@ -566,15 +580,23 @@ class Calendar extends React.Component {
                     }
                     {is_mounted
                         ?
-                        <CalendarBody
-                            meetings={meetings}
-                            limit={this.props.limit}
-                            openFancy={this.openFancy}
-                            closedFancy={this.closedFancy}
-                            login_initial={this.props.login_initial}
-                        />
+                        <div className={calendarClass + '__body-appear'}>
+                            {isLoadingMore &&
+                                <p className={calendarClass + '__loading-more'}>
+                                    <span className={calendarClass + '__loading-more__dot'}/>
+                                    {StringStore.get('CALENDAR_LOADING_MORE_DAYS') || 'Cargando más días...'}
+                                </p>
+                            }
+                            <CalendarBody
+                                meetings={meetings}
+                                limit={this.props.limit}
+                                openFancy={this.openFancy}
+                                closedFancy={this.closedFancy}
+                                login_initial={this.props.login_initial}
+                            />
+                        </div>
                         :
-                        <Loading/>
+                        <CalendarSkeleton/>
                     }
                 </div>
 

--- a/src/components/calendar/CalendarSkeleton.js
+++ b/src/components/calendar/CalendarSkeleton.js
@@ -1,34 +1,78 @@
 'use strict';
 
 import React from "react";
+import moment from "moment";
+import 'moment/locale/es';
+import StringStore from "../utils/Strings/StringStore";
 import '../../styles/newlook/components/GFSDK-c-CalendarSkeleton.scss';
 
 /**
  * Vista "fantasma" que se muestra mientras el calendario todavia no tiene
  * datos (is_mounted === false), en vez del loading generico de puntos.
- * Son tarjetas con la misma forma que una clase real (barra de hora, lineas
- * de texto, boton de reservar), con una animacion de "shimmer" para que se
- * sienta como que el calendario ya esta ahi, en vez de una pantalla en blanco.
+ *
+ * Imita la forma REAL del calendario (columnas por dia en desktop, una sola
+ * columna con varias tarjetas en mobile) en vez de una simple lista vertical
+ * generica, para que la transicion a los datos reales se sienta continua.
+ * Los encabezados de dia (nombre/numero) se calculan con la fecha real de
+ * hoy +6 dias, ya que eso no depende de que la data ya haya llegado.
  */
 class CalendarSkeleton extends React.Component {
+    getUpcomingDays(count) {
+        moment.locale(StringStore.getLanguage().toLowerCase());
+        const today = moment();
+        const days = [];
+
+        for (let i = 0; i < count; i++) {
+            const date = moment(today).add(i, 'days');
+            days.push({
+                dayName: date.format('dd'),
+                dayNumber: date.format('D'),
+            });
+        }
+
+        return days;
+    }
+
+    renderCard(columnIndex, cardIndex) {
+        const preC = 'GFSDK-c';
+        const skeletonClass = preC + '-CalendarSkeleton';
+
+        return (
+            <div className={skeletonClass + '__card'} key={`calendar-skeleton-card--${columnIndex}-${cardIndex}`}>
+                <div className={skeletonClass + '__time'}/>
+                <div className={skeletonClass + '__line ' + skeletonClass + '__line--title'}/>
+                <div className={skeletonClass + '__line ' + skeletonClass + '__line--subtitle'}/>
+                <div className={skeletonClass + '__line ' + skeletonClass + '__line--meta'}/>
+                <div className={skeletonClass + '__pill'}/>
+            </div>
+        );
+    }
+
     render() {
         const preC = 'GFSDK-c';
         const skeletonClass = preC + '-CalendarSkeleton';
-        const cards = [0, 1, 2, 3];
+        const days = this.getUpcomingDays(7);
 
         return (
             <div className={skeletonClass} aria-hidden="true">
-                {cards.map((index) => (
-                    <div className={skeletonClass + '__card'} key={`calendar-skeleton-card--${index}`}>
-                        <div className={skeletonClass + '__time'}/>
-                        <div className={skeletonClass + '__body'}>
-                            <div className={skeletonClass + '__line ' + skeletonClass + '__line--title'}/>
-                            <div className={skeletonClass + '__line ' + skeletonClass + '__line--subtitle'}/>
-                            <div className={skeletonClass + '__line ' + skeletonClass + '__line--meta'}/>
+                <div className={skeletonClass + '__header'}>
+                    {days.map((day, index) => (
+                        <div className={skeletonClass + '__header-day'} key={`calendar-skeleton-header--${index}`}>
+                            <p className={skeletonClass + '__header-day-name'}>{day.dayName}</p>
+                            <p className={skeletonClass + '__header-day-number'}>{day.dayNumber}</p>
                         </div>
-                        <div className={skeletonClass + '__pill'}/>
-                    </div>
-                ))}
+                    ))}
+                </div>
+                <div className={skeletonClass + '__columns'}>
+                    {days.map((day, columnIndex) => (
+                        <div className={skeletonClass + '__column'} key={`calendar-skeleton-column--${columnIndex}`}>
+                            {[0, 1].map((cardIndex) => this.renderCard(columnIndex, cardIndex))}
+                        </div>
+                    ))}
+                </div>
+                <div className={skeletonClass + '__mobile'}>
+                    {[0, 1, 2, 3].map((cardIndex) => this.renderCard('mobile', cardIndex))}
+                </div>
             </div>
         );
     }

--- a/src/components/calendar/CalendarSkeleton.js
+++ b/src/components/calendar/CalendarSkeleton.js
@@ -1,0 +1,37 @@
+'use strict';
+
+import React from "react";
+import '../../styles/newlook/components/GFSDK-c-CalendarSkeleton.scss';
+
+/**
+ * Vista "fantasma" que se muestra mientras el calendario todavia no tiene
+ * datos (is_mounted === false), en vez del loading generico de puntos.
+ * Son tarjetas con la misma forma que una clase real (barra de hora, lineas
+ * de texto, boton de reservar), con una animacion de "shimmer" para que se
+ * sienta como que el calendario ya esta ahi, en vez de una pantalla en blanco.
+ */
+class CalendarSkeleton extends React.Component {
+    render() {
+        const preC = 'GFSDK-c';
+        const skeletonClass = preC + '-CalendarSkeleton';
+        const cards = [0, 1, 2, 3];
+
+        return (
+            <div className={skeletonClass} aria-hidden="true">
+                {cards.map((index) => (
+                    <div className={skeletonClass + '__card'} key={`calendar-skeleton-card--${index}`}>
+                        <div className={skeletonClass + '__time'}/>
+                        <div className={skeletonClass + '__body'}>
+                            <div className={skeletonClass + '__line ' + skeletonClass + '__line--title'}/>
+                            <div className={skeletonClass + '__line ' + skeletonClass + '__line--subtitle'}/>
+                            <div className={skeletonClass + '__line ' + skeletonClass + '__line--meta'}/>
+                        </div>
+                        <div className={skeletonClass + '__pill'}/>
+                    </div>
+                ))}
+            </div>
+        );
+    }
+}
+
+export default CalendarSkeleton;

--- a/src/components/calendar/CalendarStorage.js
+++ b/src/components/calendar/CalendarStorage.js
@@ -26,6 +26,12 @@ const CalendarStorage = {
     visualization: false,
     show_parent: false,
 
+    // Cuenta cuantas peticiones de reuniones siguen pendientes (una por cada
+    // tramo de fechas x ubicacion/sala que dispara GafaThemeSDK.renderMeetingsCalendar).
+    // Sirve para mostrar un indicador chico de "cargando mas dias..." mientras
+    // la primera semana ya se ve real pero el resto sigue en camino.
+    pendingMeetingRequests: 0,
+
     /**
      *
      * @param property

--- a/src/components/utils/Strings/Strings_EN.js
+++ b/src/components/utils/Strings/Strings_EN.js
@@ -61,6 +61,7 @@ export default {
     ROOM: 'Room',
     NEXT_WEEK: 'Next week',
     PREVIOUS_WEEK: 'Previous week',
+    CALENDAR_LOADING_MORE_DAYS: 'Loading more days...',
     CALENDAR: 'Calendar',
     NOT_ACCOUNT_QUESTION: "Don\'t have an account yet?",
     ACCOUNT_QUESTION: "Already have an account?",

--- a/src/components/utils/Strings/Strings_ES.js
+++ b/src/components/utils/Strings/Strings_ES.js
@@ -65,6 +65,7 @@ export default {
   ROOM: "Salón",
   NEXT_WEEK: "Siguiente semana",
   PREVIOUS_WEEK: "Semana anterior",
+  CALENDAR_LOADING_MORE_DAYS: "Cargando más días...",
   CALENDAR: "Calendario",
   NOT_ACCOUNT_QUESTION: "¿Aún no tienes una cuenta?",
   ACCOUNT_QUESTION: "¿Ya tienes una cuenta?",

--- a/src/styles/newlook/components/GFSDK-c-CalendarSkeleton.scss
+++ b/src/styles/newlook/components/GFSDK-c-CalendarSkeleton.scss
@@ -47,28 +47,52 @@
   }
 }
 
+// Imita la forma REAL del calendario (columnas por dia en desktop, con
+// header de dia/numero real; una sola columna con tarjetas en mobile, como
+// el slider real de un dia a la vez) en vez de una lista vertical generica.
 .#{$pre}-c-CalendarSkeleton {
-  display: grid;
-  row-gap: 12px;
-  padding: 15px 0;
   width: 100%;
   box-sizing: border-box;
+  padding: 15px 0;
+
+  &__header,
+  &__columns {
+    display: none;
+  }
+
+  &__header-day-name,
+  &__header-day-number {
+    border-radius: 6px;
+    background: linear-gradient(90deg, #EFEFEF 25%, #F6F6F6 37%, #EFEFEF 63%);
+    background-size: 450px 100%;
+    animation: GFSDKCalendarSkeletonShimmer 1.4s ease-in-out infinite;
+    margin: 0 auto;
+  }
+
+  &__header-day-name {
+    width: 60%;
+    height: 9px;
+    margin-bottom: 6px;
+  }
+
+  &__header-day-number {
+    width: 40%;
+    height: 13px;
+  }
+
+  &__mobile {
+    display: grid;
+    row-gap: 12px;
+  }
 
   &__card {
     display: grid;
-    grid-template-columns: 80px 1fr 100px;
-    align-items: center;
-    column-gap: 15px;
+    row-gap: 8px;
     border: 1px solid #EEEEEE;
     border-radius: 10px;
     background-color: #FFFFFF;
     padding: 15px;
     box-sizing: border-box;
-
-    @media screen and (max-width: 991px) {
-      grid-template-columns: 56px 1fr 64px;
-      column-gap: 10px;
-    }
   }
 
   &__time,
@@ -81,35 +105,64 @@
   }
 
   &__time {
-    height: 32px;
-    width: 100%;
+    height: 16px;
+    width: 45%;
     border-radius: 8px;
   }
 
-  &__body {
-    display: grid;
-    row-gap: 8px;
-  }
-
   &__line {
-    height: 10px;
+    height: 9px;
 
     &--title {
-      width: 70%;
-      height: 12px;
+      width: 75%;
+      height: 11px;
     }
 
     &--subtitle {
-      width: 50%;
+      width: 55%;
     }
 
     &--meta {
-      width: 35%;
+      width: 40%;
     }
   }
 
   &__pill {
-    height: 34px;
+    height: 30px;
+    width: 100%;
     border-radius: 999px;
+    margin-top: 4px;
+  }
+
+  // A partir de aqui, replica el layout REAL de la vista "vertical" en
+  // desktop: GFSDK-c-Calendar__header_vertical / __week_body_vertical /
+  // __day_column_vertical usan el mismo 14% de ancho por columna (7 dias).
+  @media screen and (min-width: 992px) {
+    &__mobile {
+      display: none;
+    }
+
+    &__header,
+    &__columns {
+      display: inline-flex;
+      width: 100%;
+    }
+
+    &__header {
+      margin-bottom: 10px;
+    }
+
+    &__header-day {
+      width: 14%;
+      text-align: center;
+    }
+
+    &__column {
+      width: 14%;
+      padding: 0 5px;
+      box-sizing: border-box;
+      display: grid;
+      row-gap: 15px;
+    }
   }
 }

--- a/src/styles/newlook/components/GFSDK-c-CalendarSkeleton.scss
+++ b/src/styles/newlook/components/GFSDK-c-CalendarSkeleton.scss
@@ -1,0 +1,115 @@
+@import '../base/variables.scss';
+
+@keyframes GFSDKCalendarSkeletonShimmer {
+  0% {
+    background-position: -450px 0;
+  }
+  100% {
+    background-position: 450px 0;
+  }
+}
+
+@keyframes GFSDKCalendarFadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+// Se aplica al contenedor real del calendario (CalendarBody) la primera vez
+// que reemplaza al skeleton, para que no aparezca de golpe.
+.#{$pre}-c-Calendar__body-appear {
+  animation: GFSDKCalendarFadeIn .4s ease;
+}
+
+// Indicador chico y discreto de "cargando mas dias..." mientras llega el
+// resto del rango en segundo plano (la primera semana ya se muestra real).
+.#{$pre}-c-Calendar__loading-more {
+  display: flex;
+  align-items: center;
+  column-gap: 8px;
+  color: #8E8E93;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 12px;
+  letter-spacing: .3px;
+  padding: 6px 0 14px;
+
+  &__dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background-color: #C7C7C8;
+    animation: GFSDKCalendarSkeletonShimmer 1.2s ease-in-out infinite alternate;
+  }
+}
+
+.#{$pre}-c-CalendarSkeleton {
+  display: grid;
+  row-gap: 12px;
+  padding: 15px 0;
+  width: 100%;
+  box-sizing: border-box;
+
+  &__card {
+    display: grid;
+    grid-template-columns: 80px 1fr 100px;
+    align-items: center;
+    column-gap: 15px;
+    border: 1px solid #EEEEEE;
+    border-radius: 10px;
+    background-color: #FFFFFF;
+    padding: 15px;
+    box-sizing: border-box;
+
+    @media screen and (max-width: 991px) {
+      grid-template-columns: 56px 1fr 64px;
+      column-gap: 10px;
+    }
+  }
+
+  &__time,
+  &__pill,
+  &__line {
+    border-radius: 6px;
+    background: linear-gradient(90deg, #EFEFEF 25%, #F6F6F6 37%, #EFEFEF 63%);
+    background-size: 450px 100%;
+    animation: GFSDKCalendarSkeletonShimmer 1.4s ease-in-out infinite;
+  }
+
+  &__time {
+    height: 32px;
+    width: 100%;
+    border-radius: 8px;
+  }
+
+  &__body {
+    display: grid;
+    row-gap: 8px;
+  }
+
+  &__line {
+    height: 10px;
+
+    &--title {
+      width: 70%;
+      height: 12px;
+    }
+
+    &--subtitle {
+      width: 50%;
+    }
+
+    &--meta {
+      width: 35%;
+    }
+  }
+
+  &__pill {
+    height: 34px;
+    border-radius: 999px;
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Contexto
Sigue a la mejora de rendimiento del calendario ([PR #195](https://github.com/GafaMX/GFtheme/pull/195), ya en `dev-SDK-webapp` y desplegado). Esta parte es puramente visual/UX: mejorar cómo se **siente** la carga, no cuánto tarda.

## Qué cambia

1. **Skeleton cards con shimmer.** El loading genérico de 4 puntos rebotando se reemplaza, solo en el calendario, por tarjetas "fantasma" con la forma real de una clase (barra de hora, líneas de texto, botón), con una animación de brillo (`shimmer`) moviéndose. Componente nuevo: `CalendarSkeleton.js`.
2. **Indicador discreto de "Cargando más días..."** Con la carga progresiva del PR #195, la primera semana ya llega rápido y se muestra real; ahora, mientras el resto del rango sigue llegando en segundo plano, aparece un texto chico y discreto (no un loading de pantalla completa) avisando que todavía hay más días en camino. Se apoya en un contador nuevo (`pendingMeetingRequests`) que `GafaThemeSDK` lleva por cada tramo de fechas × ubicación/sala que dispara.
3. **Fade-in suave** cuando el contenido real reemplaza al skeleton, en vez de aparecer de golpe.

No se tocó el componente `Loading.js` global (se usa en perfil, staff, servicios, membresías, login, etc.) — todo esto es específico del calendario, para no afectar nada más.

## Verificación hecha
- `npm run build` compila sin errores nuevos.
- Probado visualmente con datos reales de Bunker Indoor Golf (company 190) vía un túnel temporal: se ve el skeleton con shimmer mientras carga, luego el fade-in al contenido real, y el indicador de "cargando más días" mientras llega el resto del rango.
- `dist/main.min.js` no se regeneró/commiteó en este PR — falta correr `npm run build` y commitear antes de desplegar a `buq-sdk-dev`.

## Cómo probarlo / cancelarlo
- Sigue en **draft**, apilado conceptualmente sobre el trabajo de rendimiento ya en `dev-SDK-webapp`.
- Si el estilo/look no convence, se ajusta el CSS (`GFSDK-c-CalendarSkeleton.scss`) o se cierra sin mergear — no depende de nada más.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-741cc4c6-ac85-4635-a285-8e7459076468?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-741cc4c6-ac85-4635-a285-8e7459076468&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

