### PR TITLE
fix(auth): el fancy de reserva/compra no se abría después de login o registro

### DIFF
--- a/src/components/auth/Login.js
+++ b/src/components/auth/Login.js
@@ -116,8 +116,51 @@ class Login extends React.Component {
         this.setState({serverError: error, logged: false});
     }
 
+    /**
+     * Abre visualmente el contenedor [data-gf-theme="fancy"] (agrega las clases
+     * `active`/`show` que su CSS requiere para dejar de estar en opacity:0 y
+     * pointer-events:none) y engancha el boton de cerrar una vez que el
+     * contenido llegue. Sin esto, el fancy se rellenaba de contenido pero
+     * quedaba invisible/no interactivo: CalendarMeeting/ComboItem/MembershipItem
+     * ya hacen esto para el flujo de click directo estando logueado, pero el
+     * flujo de "comprar/reservar despues de hacer login" (mas abajo) nunca lo
+     * hacia.
+     */
+    openFancyContainerAndWireClose() {
+        const fancy = document.querySelector('[data-gf-theme="fancy"]');
+        fancy.classList.add('active');
+
+        setTimeout(function () {
+            fancy.classList.add('show');
+        }, 400);
+
+        function getFancy() {
+            if (document.querySelector('[data-gf-theme="fancy"]').firstChild) {
+                const closeFancy = document.getElementById('CreateReservationFancyTemplate--Close');
+
+                closeFancy.addEventListener('click', function (e) {
+                    var event_before = new Event('buq__reservation_fancy_before_closed');
+                    dispatchEvent(event_before);
+                    fancy.removeChild(document.querySelector('[data-gf-theme="fancy"]').firstChild);
+
+                    fancy.classList.remove('show');
+
+                    setTimeout(function () {
+                        fancy.classList.remove('active');
+                        fancy.innerHTML = '<div class="spinner"><div class="bounce1"></div><div class="bounce2"></div><div class="bounce3"></div></div>';
+                    }, 400);
+                });
+            } else {
+                setTimeout(getFancy, 1000);
+            }
+        }
+
+        return getFancy;
+    }
+
     buyComboAfterLogin() {
         let comp = this;
+        let getFancy = this.openFancyContainerAndWireClose();
 
         GafaFitSDKWrapper.getFancyForBuyCombo(
             window.GFtheme.brand_slug,
@@ -128,11 +171,14 @@ class Login extends React.Component {
                 window.GFtheme.combo_id = null;
                 window.GFtheme.brand_slug = null;
                 window.GFtheme.location_slug = null;
+                getFancy();
             });
     }
 
     buyMembershipAfterLogin() {
         let comp = this;
+        let getFancy = this.openFancyContainerAndWireClose();
+
         GafaFitSDKWrapper.getFancyForBuyMembership(
             window.GFtheme.brand_slug,
             window.GFtheme.location_slug,
@@ -142,11 +188,14 @@ class Login extends React.Component {
                 window.GFtheme.membership_id = null;
                 window.GFtheme.brand_slug = null;
                 window.GFtheme.location_slug = null;
+                getFancy();
             });
     }
 
     reserveMeetingAfterLogin() {
         let comp = this;
+        let getFancy = this.openFancyContainerAndWireClose();
+
         GafaFitSDKWrapper.getFancyForMeetingReservation(
             window.GFtheme.brand_slug,
             window.GFtheme.location_slug,
@@ -156,6 +205,7 @@ class Login extends React.Component {
                 window.GFtheme.meetings_id = null;
                 window.GFtheme.location_slug = null;
                 window.GFtheme.brand_slug = null;
+                getFancy();
             });
     }
 

--- a/src/components/auth/Register.js
+++ b/src/components/auth/Register.js
@@ -260,8 +260,49 @@ class Register extends React.Component {
         );
     }
 
+    /**
+     * Igual que en Login.js: sin esto el fancy se rellenaba de contenido pero
+     * quedaba invisible/no interactivo (opacity:0, pointer-events:none por
+     * defecto en su CSS) porque a este flujo de "comprar/reservar despues de
+     * registrarse" le faltaba agregar las clases `active`/`show` y enganchar
+     * el boton de cerrar, cosa que CalendarMeeting/ComboItem/MembershipItem
+     * si hacen para el flujo de click directo estando logueado.
+     */
+    openFancyContainerAndWireClose() {
+        const fancy = document.querySelector('[data-gf-theme="fancy"]');
+        fancy.classList.add('active');
+
+        setTimeout(function () {
+            fancy.classList.add('show');
+        }, 400);
+
+        function getFancy() {
+            if (document.querySelector('[data-gf-theme="fancy"]').firstChild) {
+                const closeFancy = document.getElementById('CreateReservationFancyTemplate--Close');
+
+                closeFancy.addEventListener('click', function (e) {
+                    var event_before = new Event('buq__reservation_fancy_before_closed');
+                    dispatchEvent(event_before);
+                    fancy.removeChild(document.querySelector('[data-gf-theme="fancy"]').firstChild);
+
+                    fancy.classList.remove('show');
+
+                    setTimeout(function () {
+                        fancy.classList.remove('active');
+                        fancy.innerHTML = '<div class="spinner"><div class="bounce1"></div><div class="bounce2"></div><div class="bounce3"></div></div>';
+                    }, 400);
+                });
+            } else {
+                setTimeout(getFancy, 1000);
+            }
+        }
+
+        return getFancy;
+    }
+
     buyComboAfterRegister() {
         let comp = this;
+        let getFancy = this.openFancyContainerAndWireClose();
 
         GafaFitSDKWrapper.getFancyForBuyCombo(
             window.GFtheme.brand_slug,
@@ -272,11 +313,14 @@ class Register extends React.Component {
                 window.GFtheme.combo_id = null;
                 window.GFtheme.brand_slug = null;
                 window.GFtheme.location_slug = null;
+                getFancy();
             });
     }
 
     buyMembershipAfterRegister() {
         let comp = this;
+        let getFancy = this.openFancyContainerAndWireClose();
+
         GafaFitSDKWrapper.getFancyForBuyMembership(
             window.GFtheme.brand_slug,
             window.GFtheme.location_slug,
@@ -286,11 +330,14 @@ class Register extends React.Component {
                 window.GFtheme.membership_id = null;
                 window.GFtheme.brand_slug = null;
                 window.GFtheme.location_slug = null;
+                getFancy();
             });
     }
 
     reserveMeetingAfterRegister() {
         let comp = this;
+        let getFancy = this.openFancyContainerAndWireClose();
+
         GafaFitSDKWrapper.getFancyForMeetingReservation(
             window.GFtheme.brand_slug,
             window.GFtheme.location_slug,
@@ -300,6 +347,7 @@ class Register extends React.Component {
                 window.GFtheme.meetings_id = null;
                 window.GFtheme.location_slug = null;
                 window.GFtheme.brand_slug = null;
+                getFancy();
             });
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## El bug reportado
En `demo.mybuq.app/reservar-prueba-actualizacion/`: clic en una clase sin sesión iniciada → aparece el login → después de iniciar sesión, el fancy de reserva ya no aparece.

## Diagnóstico
**Esto NO lo causaron los fixes de rendimiento del calendario (#195) ni el trabajo de skeleton (#196).** Rastreé el flujo completo en el código y encontré un bug estructural preexistente en `Login.js`/`Register.js` — archivos que no había tocado antes en ninguno de mis PRs.

El contenedor del fancy tiene este CSS (`src/styles/newlook/fancy.scss`):
```css
[data-gf-theme="fancy"] {
  opacity: 0;
  pointer-events: none;
  ...
  &.active { pointer-events: all; }
  &.show { opacity: 1; }
}
```
Es decir: **invisible y no clickeable por defecto**, hasta que algo le agregue las clases `active`/`show`.

Los 4 lugares donde se abre el fancy en un click directo (usuario ya logueado) sí agregan esas clases: `CalendarMeeting.js`, `ComboItem.js`, `MembershipItem.js`, `PurchaseButton.js`.

Pero el flujo de **"comprar/reservar DESPUÉS de hacer login o registro"** (cuando el usuario clickea sin sesión, hace login, y se supone que retoma la compra) — en `Login.js`: `reserveMeetingAfterLogin()`, `buyComboAfterLogin()`, `buyMembershipAfterLogin()`; y en `Register.js` sus equivalentes — **nunca agregaban esas clases**. El contenido del fancy sí se cargaba (la llamada a `GetCreateReservationForm` funcionaba), pero quedaba invisible e inclickeable.

Probablemente este bug existía desde hace tiempo y no se había notado porque el calendario tardaba ~30 segundos en cargar antes, lo que posiblemente desalentaba probar el flujo completo (clic → login → reservar) de punta a punta con frecuencia. Al ya cargar rápido, la prueba llegó más lejos y lo hizo evidente.

## El fix
Se agregó el mismo patrón que ya usan los otros 4 archivos (agregar clases `active`/`show`, y enganchar el botón de cerrar del fancy) a los 3 métodos de `Login.js` y los 3 equivalentes de `Register.js`.

## Verificación hecha
- `npm run build` compila sin errores nuevos.
- **No pude probar interactivamente el flujo de login real** (no tengo herramienta de navegador/automatización en este entorno) — necesito que lo prueben ustedes con las credenciales de `demo.mybuq.app/reservar-prueba-actualizacion/` para confirmar que esto sí resuelve el síntoma exacto que reportaron.

## Cómo probarlo / cancelarlo
- Draft, sin mergear. Base: `dev-SDK-webapp` (donde está el bug hoy).
- Si no resuelve el problema o hay algo más, se cierra sin mergear y seguimos investigando con más detalle (idealmente con la consola del navegador abierta durante la prueba, para ver si hay algún error de JS que se me haya escapado).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-741cc4c6-ac85-4635-a285-8e7459076468?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-741cc4c6-ac85-4635-a285-8e7459076468&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

