### PR TITLE
fix(checkout): canjear códigos de descuento (BUQMX dejaba Código no válido)

### DIFF
--- a/packages/react-sdk/src/sdk/cart/discountCode.test.ts
+++ b/packages/react-sdk/src/sdk/cart/discountCode.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCheckDiscountUrl,
+  discountAmountFromCode,
+  parseDiscountCheckResponse,
+  resolveDiscountAmount,
+} from "./discountCode";
+
+const base = {
+  apiBaseUrl: "https://buq.partners/",
+  brandSlug: "fitspin",
+  locationSlug: "helipuerto",
+  code: "BUQMX",
+  lines: [{ id: 971, type: "combo" as const }],
+};
+
+describe("buildCheckDiscountUrl", () => {
+  it("pone el perfil del usuario en la ruta, no el meeting", () => {
+    const url = buildCheckDiscountUrl({ ...base, userProfileId: 4412 });
+    expect(url.pathname).toBe(
+      "/api/brand/fitspin/location/helipuerto/reservation/check-discount-code/BUQMX/4412",
+    );
+    expect(url.pathname.endsWith("/123456")).toBe(false);
+    expect(url.searchParams.getAll("combo[]")).toEqual(["971"]);
+  });
+
+  it("usa la URL del fancy y sustituye _|_", () => {
+    const url = buildCheckDiscountUrl({
+      ...base,
+      urlTemplate:
+        "https://buq.partners/api/brand/fitspin/location/helipuerto/reservation/check-discount-code/_|_/4412",
+      userProfileId: 1,
+    });
+    expect(url.pathname).toContain("/check-discount-code/BUQMX/4412");
+    expect(url.pathname).not.toContain("_|_");
+  });
+
+  it("no arma la ruta si falta el perfil y no hay template", () => {
+    expect(() => buildCheckDiscountUrl({ ...base })).toThrow(/validar el código/i);
+  });
+});
+
+describe("discountAmountFromCode", () => {
+  it("aplica percent sobre el subtotal (BUQMX = 90%)", () => {
+    expect(discountAmountFromCode({ discountType: "percent", discountNumber: 90 }, 330)).toBe(297);
+  });
+
+  it("aplica price como monto fijo, igual que el fancy v1", () => {
+    expect(discountAmountFromCode({ discountType: "price", discountNumber: 50 }, 330)).toBe(50);
+  });
+});
+
+describe("parseDiscountCheckResponse", () => {
+  it("lee el objeto real de gafa.fit (discount_type + discount_number)", () => {
+    const result = parseDiscountCheckResponse("BUQMX", true, {
+      id: 1722,
+      code: "BUQMX",
+      discount_type: "percent",
+      discount_number: 90,
+    });
+    expect(result.valid).toBe(true);
+    expect(result.discountType).toBe("percent");
+    expect(result.discountNumber).toBe(90);
+    expect(result.label).toBe("BUQMX · 90%");
+    expect(resolveDiscountAmount(result, 330)).toBe(297);
+  });
+
+  it("trata el 404 de UserProfile (meetingId mal puesto) como inválido", () => {
+    const result = parseDiscountCheckResponse("BUQMX", false, {
+      message: "No query results for model [App\\Models\\User\\UserProfile] 98765",
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  it("saca el mensaje de un 422 de código inexistente", () => {
+    const result = parseDiscountCheckResponse("NOEXISTE", false, {
+      message: "The given data was invalid.",
+      errors: { user: ["Código de descuento inválido"] },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.message).toBe("Código de descuento inválido");
+  });
+
+  it("trata el body string de 'sin producto' como error, no como éxito", () => {
+    const result = parseDiscountCheckResponse("BUQMX", true, "No se ha definido un producto válido.");
+    expect(result.valid).toBe(false);
+    expect(result.message).toMatch(/producto/i);
+  });
+});

--- a/packages/react-sdk/src/sdk/cart/discountCode.ts
+++ b/packages/react-sdk/src/sdk/cart/discountCode.ts
@@ -1,0 +1,125 @@
+import type { CartLineType, DiscountCodeResult } from "../client/types";
+
+/** El fancy v1 sustituye este marcador en `urlCheckDiscountCode` por el código. */
+export const DISCOUNT_CODE_PLACEHOLDER = "_|_";
+
+export type DiscountLine = { id: number; type: CartLineType };
+
+export type BuildCheckDiscountUrlInput = {
+  apiBaseUrl: string;
+  brandSlug: string;
+  locationSlug: string;
+  code: string;
+  /** `users_profiles.id` — último segmento de la ruta, NO el meeting. */
+  userProfileId?: string | number;
+  /** URL del create-form-template, con `_|_` donde va el código. */
+  urlTemplate?: string;
+  lines: DiscountLine[];
+};
+
+/**
+ * El fancy v1 hace GET a `urlCheckDiscountCode.replace("_|_", code)` con
+ * `combo` / `membership` / `product` (arrays). El último segmento de la ruta
+ * es el perfil del usuario; si se manda el meetingId ahí, Laravel busca un
+ * UserProfile que no existe y responde 404 → "Código no válido".
+ */
+export function buildCheckDiscountUrl(input: BuildCheckDiscountUrlInput): URL {
+  const code = input.code.trim();
+  if (!code) throw new Error("Escribe un código de descuento.");
+
+  const base = input.apiBaseUrl.endsWith("/") ? input.apiBaseUrl : `${input.apiBaseUrl}/`;
+  const template = input.urlTemplate?.trim();
+  let href: string;
+
+  if (template && template.includes(DISCOUNT_CODE_PLACEHOLDER)) {
+    href = template.replace(DISCOUNT_CODE_PLACEHOLDER, code);
+  } else if (input.userProfileId != null && String(input.userProfileId) !== "") {
+    const origin = new URL(base);
+    href = `${origin.origin}/api/brand/${input.brandSlug}/location/${input.locationSlug}/reservation/check-discount-code/${encodeURIComponent(code)}/${input.userProfileId}`;
+  } else if (template) {
+    href = template;
+  } else {
+    throw new Error("No pudimos validar el código. Recarga e intenta de nuevo.");
+  }
+
+  const url = new URL(href, base);
+  for (const line of input.lines) {
+    const key =
+      line.type === "combo" ? "combo[]" : line.type === "membership" ? "membership[]" : "product[]";
+    url.searchParams.append(key, String(line.id));
+  }
+  return url;
+}
+
+/** Igual que `discountInTotalForDiscountCode` del fancy v1. */
+export function discountAmountFromCode(
+  discount: Pick<DiscountCodeResult, "discountType" | "discountNumber">,
+  subtotal: number,
+): number {
+  const value = Number(discount.discountNumber);
+  if (!Number.isFinite(value) || subtotal <= 0) return 0;
+  switch (discount.discountType) {
+    case "price":
+      return value;
+    case "percent":
+      return (value * subtotal) / 100;
+    default:
+      return 0;
+  }
+}
+
+export function resolveDiscountAmount(result: DiscountCodeResult | null | undefined, subtotal: number): number {
+  if (!result?.valid) return 0;
+  if (result.discountType && result.discountNumber != null) {
+    return Math.max(0, discountAmountFromCode(result, subtotal));
+  }
+  return Math.max(0, result.discountAmount ?? 0);
+}
+
+export function discountCheckErrorMessage(data: unknown): string | undefined {
+  if (typeof data === "string" && data.trim()) return data.trim();
+  if (!data || typeof data !== "object") return undefined;
+  const body = data as { message?: string; errors?: Record<string, string[]> };
+  const firstField = body.errors ? Object.values(body.errors).flat().find(Boolean) : undefined;
+  if (firstField) return firstField;
+  if (typeof body.message === "string" && body.message.trim()) return body.message.trim();
+  return undefined;
+}
+
+export function parseDiscountCheckResponse(code: string, ok: boolean, data: unknown): DiscountCodeResult {
+  if (!ok) {
+    return { valid: false, code, message: discountCheckErrorMessage(data) ?? "Código no válido" };
+  }
+  if (typeof data === "string") {
+    return { valid: false, code, message: data.trim() || "Código no válido" };
+  }
+  if (!data || typeof data !== "object") {
+    return { valid: false, code, message: "Código no válido" };
+  }
+
+  const raw = data as Record<string, unknown>;
+  const discountType = typeof raw.discount_type === "string" ? raw.discount_type : undefined;
+  const parsedNumber =
+    typeof raw.discount_number === "number" ? raw.discount_number : Number(raw.discount_number);
+  const discountNumber = Number.isFinite(parsedNumber) ? parsedNumber : undefined;
+  const looksLikeCode = raw.id != null && (typeof raw.code === "string" || Boolean(discountType));
+  if (!looksLikeCode) {
+    return { valid: false, code, message: discountCheckErrorMessage(data) ?? "Código no válido" };
+  }
+
+  const label =
+    typeof raw.short_description === "string" && raw.short_description
+      ? raw.short_description
+      : discountType === "percent" && discountNumber != null
+        ? `${code} · ${discountNumber}%`
+        : code;
+
+  return {
+    valid: true,
+    code,
+    label,
+    discountType,
+    discountNumber,
+    raw,
+  };
+}

--- a/packages/react-sdk/src/sdk/client/httpGafaClient.ts
+++ b/packages/react-sdk/src/sdk/client/httpGafaClient.ts
@@ -8,7 +8,6 @@ import type {
   CreateReservationPayload,
   CustomFieldValues,
   CreateReservationResult,
-  DiscountCodeResult,
   FrontPaymentMethod,
   GafaClient,
   GiftCodeResult,
@@ -37,6 +36,7 @@ import type {
   UpdateProfilePayload,
 } from "./types";
 import type { GafaSdkConfig } from "../config";
+import { buildCheckDiscountUrl, parseDiscountCheckResponse } from "../cart/discountCode";
 import {
   clearStoredToken,
   readStoredToken,
@@ -1313,38 +1313,18 @@ export function createHttpGafaClient(config: GafaSdkConfig, legacy?: GafaClient)
     },
 
     async checkDiscountCode(payload) {
-      const meetingPart = payload.meetingId != null ? String(payload.meetingId) : "";
-      const url = new URL(
-        `${baseUrl}/api/brand/${payload.brandSlug}/location/${payload.locationSlug}/reservation/check-discount-code/${encodeURIComponent(payload.code)}/${meetingPart}`,
-      );
-      payload.lines
-        .filter((line) => line.type === "combo")
-        .forEach((line) => url.searchParams.append("combo[]", String(line.id)));
-      payload.lines
-        .filter((line) => line.type === "membership")
-        .forEach((line) => url.searchParams.append("membership[]", String(line.id)));
-      payload.lines
-        .filter((line) => line.type === "product")
-        .forEach((line) => url.searchParams.append("product[]", String(line.id)));
-
-      const response = await fetch(url.toString(), { headers: authHeaders() });
-      if (!response.ok) {
-        return { valid: false, code: payload.code };
-      }
-      const data = (await response.json()) as Record<string, unknown>;
-      const discountAmount =
-        typeof data.discount === "number"
-          ? data.discount
-          : typeof data.amount === "number"
-            ? data.amount
-            : undefined;
-      return {
-        valid: true,
+      const url = buildCheckDiscountUrl({
+        apiBaseUrl: baseUrl,
+        brandSlug: payload.brandSlug,
+        locationSlug: payload.locationSlug,
         code: payload.code,
-        label: typeof data.name === "string" ? data.name : typeof data.label === "string" ? data.label : undefined,
-        discountAmount,
-        raw: data,
-      } satisfies DiscountCodeResult;
+        userProfileId: payload.userProfileId,
+        urlTemplate: payload.urlTemplate,
+        lines: payload.lines,
+      });
+      const response = await fetch(url.toString(), { headers: authHeaders() });
+      const data: unknown = await response.json().catch(() => null);
+      return parseDiscountCheckResponse(payload.code, response.ok, data);
     },
 
     async checkGiftCode(payload) {

--- a/packages/react-sdk/src/sdk/client/types.ts
+++ b/packages/react-sdk/src/sdk/client/types.ts
@@ -340,7 +340,11 @@ export type DiscountCodeResult = {
   valid: boolean;
   code: string;
   label?: string;
-  /** Monto a restar del total (si el API lo manda). */
+  message?: string;
+  /** `percent` | `price` — contrato del fancy v1 / gafa.fit. */
+  discountType?: string;
+  discountNumber?: number;
+  /** Monto a restar del total (si el API o el mock lo mandan ya calculado). */
   discountAmount?: number;
   raw?: unknown;
 };
@@ -512,6 +516,10 @@ export type GafaClient = {
     brandSlug: string;
     locationSlug: string;
     code: string;
+    /** `users_profiles.id`. El fancy lo pone en la ruta; el meeting NO. */
+    userProfileId?: string | number;
+    /** `urlCheckDiscountCode` del create-form-template (`_|_` = código). */
+    urlTemplate?: string;
     meetingId?: string | number;
     lines: Array<{ id: number; type: CartLineType }>;
   }): Promise<DiscountCodeResult>;

--- a/packages/react-sdk/src/sdk/widgets/CheckoutModal.tsx
+++ b/packages/react-sdk/src/sdk/widgets/CheckoutModal.tsx
@@ -4,6 +4,7 @@ import type {
   CartLineType,
   CatalogItem,
   CheckoutConfig,
+  DiscountCodeResult,
   GafaClient,
   Meeting,
 } from "../client/types";
@@ -33,6 +34,7 @@ import {
   checkoutCatalogQueryKey,
   fetchCheckoutCatalog,
 } from "../cart/checkoutCatalog";
+import { resolveDiscountAmount } from "../cart/discountCode";
 
 export type CheckoutModalProps = {
   client: GafaClient;
@@ -111,9 +113,9 @@ export function CheckoutModal({
   const [termsAccepted, setTermsAccepted] = useState(false);
   const [discountOpen, setDiscountOpen] = useState(false);
   const [discountCode, setDiscountCode] = useState("");
-  const [discountAmount, setDiscountAmount] = useState(0);
-  const [discountLabel, setDiscountLabel] = useState<string>();
+  const [appliedDiscount, setAppliedDiscount] = useState<DiscountCodeResult | null>(null);
   const [discountStatus, setDiscountStatus] = useState<"idle" | "checking" | "ok" | "error">("idle");
+  const [discountError, setDiscountError] = useState<string>();
   const [giftOpen, setGiftOpen] = useState(false);
   const [giftCode, setGiftCode] = useState("");
   const [giftStatus, setGiftStatus] = useState<"idle" | "checking" | "ok" | "error">("idle");
@@ -274,6 +276,8 @@ export function CheckoutModal({
     ? lines.filter((line) => !brandSlug || line.brandSlug === brandSlug)
     : lines;
   const subtotal = cartSubtotal(relevantLines);
+  const discountAmount = resolveDiscountAmount(appliedDiscount, subtotal);
+  const discountLabel = appliedDiscount?.label;
   const total = Math.max(0, subtotal - discountAmount);
   const cartCount = relevantLines.reduce((sum, line) => sum + line.amount, 0);
 
@@ -287,26 +291,27 @@ export function CheckoutModal({
   async function applyDiscount() {
     if (!client.checkDiscountCode || !discountCode.trim() || !brandSlug || !locationSlug) return;
     setDiscountStatus("checking");
+    setDiscountError(undefined);
+    setAppliedDiscount(null);
     try {
       const result = await client.checkDiscountCode({
         brandSlug,
         locationSlug,
         code: discountCode.trim(),
-        meetingId: meeting?.id ?? reservation?.meetingId,
+        userProfileId: config?.userProfileId ?? profileQuery.data?.id,
+        urlTemplate: config?.urls.checkDiscountCode,
         lines: relevantLines.map((line) => ({ id: line.id, type: line.type })),
       });
       if (!result.valid) {
         setDiscountStatus("error");
-        setDiscountAmount(0);
-        setDiscountLabel(undefined);
+        setDiscountError(result.message ?? "Código no válido");
         return;
       }
+      setAppliedDiscount(result);
       setDiscountStatus("ok");
-      setDiscountLabel(result.label);
-      setDiscountAmount(result.discountAmount ?? 0);
     } catch {
       setDiscountStatus("error");
-      setDiscountAmount(0);
+      setDiscountError("Código no válido");
     }
   }
 
@@ -805,14 +810,20 @@ export function CheckoutModal({
                       open={discountOpen}
                       onToggle={() => setDiscountOpen((v) => !v)}
                       value={discountCode}
-                      onChange={setDiscountCode}
+                      onChange={(value) => {
+                        setDiscountCode(value);
+                        if (discountStatus === "error") {
+                          setDiscountStatus("idle");
+                          setDiscountError(undefined);
+                        }
+                      }}
                       onApply={applyDiscount}
                       status={discountStatus}
                       hint={
                         discountStatus === "ok"
                           ? (discountLabel ?? "Descuento aplicado")
                           : discountStatus === "error"
-                            ? "Código no válido"
+                            ? (discountError ?? "Código no válido")
                             : undefined
                       }
                     />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## El error

En el checkout V2, **Aplicar** un código válido (p. ej. `BUQMX` en Fitspin, 1 clase $330) pintaba **Código no válido**. El código sí existe en gafa.fit (`discount_type: percent`, `discount_number: 90`).

## Causa

El fancy v1 hace:

```js
urlCheckDiscountCode.replace("_|_", code)  // .../check-discount-code/{code}/{users_id}
$.get(url, { combo: ids, membership: ids, product: ids })
```

y calcula el monto con `percent` → `number * subtotal / 100` o `price` → monto fijo.

El V2 reconstruía la URL así:

```
.../check-discount-code/{code}/{meetingId}
```

El último segmento es **route model binding de `UserProfile`**, no el meeting. Si ese id no es un perfil (el caso normal al comprar una clase), Laravel responde 404 `No query results for model UserProfile` y el SDK lo mostraba como código inválido. Sin meeting, la ruta terminaba en `.../CODE/` y también 404.

Además, aunque la llamada cayera en un perfil que sí existe, el SDK buscaba `data.discount` / `data.amount` y no leía `discount_type` + `discount_number`, así que no restaba el 90%.

## Fix

- Último segmento = `users_profiles.id` (el del create-form-template / `getProfile`).
- Si viene `urlCheckDiscountCode` del fancy, se usa y se sustituye `_|_`.
- Query params iguales al v1: `combo[]`, `membership[]`, `product[]`.
- Monto: `percent` / `price` sobre el subtotal (se recalcula si cambia el carrito).
- 422 y el body string `"No se ha definido un producto válido."` se muestran como error, no como éxito.

## Fitspin

Copiar `packages/react-sdk/src` de esta rama a `lib/gafa-react-sdk`.

## Verificación

`npm test` y `npm run typecheck` en `packages/react-sdk` (19 tests). Contra producción Fitspin:

| Request | Resultado |
| --- | --- |
| `.../BUQMX` (sin users_id) | 404 |
| `.../BUQMX/{meetingId que no es perfil}` | 404 UserProfile → el bug |
| `.../BUQMX/{users_id}?combo[]=971` | 200, BUQMX 90% → $330 − $297 = **$33** |
| `.../NOEXISTE/{users_id}?combo[]=971` | 422 Código de descuento inválido |

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-05c170fe-fc4e-4b66-80d7-47eac7f51494?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05c170fe-fc4e-4b66-80d7-47eac7f51494&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

