### PR TITLE
feat(v2): Replit carga el SDK en vivo desde Vite

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Hay una iniciativa activa para reemplazar el theme legacy (Webpack4/Babel6/React
 - **Dos builds Vite, no mezclarlos:**
   - `vite.config.ts` — librería ES+UMD con `react`/`react-dom` **externos** (para apps que ya tienen React). **No** se pega en WordPress.
   - `vite.embed.config.ts` — IIFE `gafa-sdk.js` con React **dentro**, drop-in como el theme v1. Es el artefacto que se lanza a socios. Receta: `docs/v2-lanzamiento.md`.
-- **No copiar `packages/react-sdk/src` a Replit** (`lib/gafa-react-sdk`). Relanzar Replit reinicia toda la app multi-sitio; V2 se actualiza reemplazando `docs/v2-sdk/gafa-sdk.js`. Replit se queda para sitios que no son V2.
+- **No copiar `packages/react-sdk/src` a Replit** (`lib/gafa-react-sdk`). Relanzar Replit reinicia toda la app multi-sitio. V2 en Replit se monta con un `<script>` remoto (`docs/v2-replit.md`): Vite en vivo (`/src/sdk/embed.ts`) o el IIFE publicado. Los sitios que no son V2 no se tocan.
 - **Cómo correr el preview local:**
   ```bash
   cd packages/react-sdk

--- a/docs/v2-lanzamiento.md
+++ b/docs/v2-lanzamiento.md
@@ -24,9 +24,15 @@ packages/react-sdk/src  →  npm run publish:embed  →  docs/v2-sdk/gafa-sdk.js
 | Host | Azure `buq-sdk*.azurewebsites.net` | jsDelivr desde este repo (inmediato) o el mismo Azure en `/v2/` |
 | Replit | No aplica | **No aplica.** No copiar `packages/react-sdk/src` a `lib/gafa-react-sdk`. |
 
-Replit se queda para los sitios que **no** son V2. Fitspin WP de producción hoy
-sigue en v1 (`main.min.js` + `buq.partners/sdk/dist/main.js`); el preview V2
-que vivía en Replit se sustituye por este script.
+Replit **sí** puede seguir teniendo Fitspin (y otros) en V2, pero **sin** copiar
+`packages/react-sdk/src`. El preview V2 de Replit carga un `<script src>` remoto.
+Receta para el agente de Replit: `docs/v2-replit.md`.
+
+- **En vivo (sin publicar):** Vite de este repo + túnel → Replit pone
+  `GAFA_SDK_V2_URL=https://<host>/src/sdk/embed.ts` (`type="module"`). Recargar
+  Fitspin. No relanzar Replit.
+- **Snapshot:** `publish:embed` + IIFE en jsDelivr / Azure (WordPress, o Replit
+  cuando quieras congelar).
 
 ## Receta para el agente de Cursor (cada cambio V2)
 

--- a/docs/v2-replit.md
+++ b/docs/v2-replit.md
@@ -1,0 +1,67 @@
+# Replit: montar el SDK v2 en vivo (sin copiar source)
+
+Las páginas V2 en Replit (Fitspin, etc.) **no llevan el TypeScript del SDK**.
+Cargan un `<script>` remoto. Los sitios que siguen en v1 no se tocan.
+
+Hay dos URLs. Replit elige con una env var, **sin relanzar toda la app**:
+
+| `GAFA_SDK_V2_URL` | Qué es | Cuándo |
+| --- | --- | --- |
+| `https://<vite-publico>/src/sdk/embed.ts` | Vite de este repo (`npm run dev`). Cambios en GFtheme se ven al recargar Fitspin. **No hay que publicar.** | Mientras alguien corre Vite en GFtheme (Cursor Cloud / tu máquina) con un túnel público |
+| IIFE publicado (`gafa-sdk.js`) | Snapshot. Hay que `publish:embed` + push | Preview estable / WP |
+
+## Qué tiene que hacer Replit (copiar tal cual)
+
+1. **Borrar / dejar de usar** `lib/gafa-react-sdk` (y cualquier copy-paste de `packages/react-sdk/src`). No transpilar el SDK en el build de Replit.
+2. **No relanzar** la app multi-sitio. Solo las páginas V2 cambian el script.
+3. **Dejar** `[data-gf-options]` / `[data-gafa-options]` y los contenedores (`data-gf-theme` o `data-gafa-v2`).
+4. **Quitar** el theme v1 (`main.min.js`) **solo** en esas páginas V2, o usar `data-gafa-v2` si el header todavía carga v1.
+5. Inyectar **un** script, leyendo `GAFA_SDK_V2_URL`:
+
+```html
+<!-- VIVO (Vite, type=module): -->
+<script type="module" src="GAFA_SDK_V2_URL"></script>
+
+<!-- PUBLICADO (IIFE, SIN type=module): -->
+<script src="GAFA_SDK_V2_URL"></script>
+```
+
+Regla: si la URL termina en `embed.ts` o contiene `:5173` / `vite` → `type="module"`. Si termina en `gafa-sdk.js` → script clásico.
+
+6. Los sitios no-V2 siguen igual.
+
+## Prompt para pegarle al agente de Replit
+
+```
+PARA. No copies GFtheme. No transpiles lib/gafa-react-sdk. No relances toda la app.
+
+El SDK v2 ya no vive en este repo. Las páginas V2 (Fitspin y las que ya lo tenían montado local) deben cargarlo con UN script remoto.
+
+1. Quita el montaje local: imports, copies y el folder lib/gafa-react-sdk (o equivalente). El build de Replit no debe incluir packages/react-sdk.
+
+2. Deja data-gf-options y los contenedores (data-gf-theme o data-gafa-v2). No reescribas el HTML de calendario/cuenta/combos.
+
+3. Agrega env GAFA_SDK_V2_URL. En las páginas V2, si la URL termina en .ts o va a un Vite, inyecta:
+   <script type="module" src="{GAFA_SDK_V2_URL}"></script>
+   Si termina en gafa-sdk.js:
+   <script src="{GAFA_SDK_V2_URL}"></script>
+
+4. No cargues el theme v1 (main.min.js) y el v2 a la vez en la misma página, salvo que los nodos v2 usen data-gafa-v2.
+
+5. No toques los sitios que siguen en v1.
+
+6. No hagas redeploy global. Un cambio de env / una línea de script basta. Recargar Fitspin en el navegador.
+
+URL inicial de desarrollo (te la pasa Gabriel cuando el Vite de GFtheme esté en un túnel):
+  https://HOST/src/sdk/embed.ts
+```
+
+## Qué corre en GFtheme (este repo)
+
+```sh
+cd packages/react-sdk
+npm run dev          # :5173, CORS abierto
+# Túnel público (cloudflared / ngrok) → esa HTTPS es GAFA_SDK_V2_URL + /src/sdk/embed.ts
+```
+
+Sin túnel, Replit no alcanza `localhost` de Cursor. Publicar a jsDelivr **no** es en vivo: es un snapshot.

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -14,6 +14,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run",
     "dev": "vite --host 0.0.0.0",
+    "dev:embed": "vite --host 0.0.0.0 --port 5173",
     "build:demo": "vite build --config vite.demo.config.ts",
     "build:embed": "vite build --config vite.embed.config.ts",
     "publish:embed": "bash ../../scripts/publish-v2-embed.sh"

--- a/packages/react-sdk/vite.config.ts
+++ b/packages/react-sdk/vite.config.ts
@@ -1,11 +1,18 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
-/** Librería (React externo). El drop-in de WP es vite.embed.config.ts. */
+/** Librería (React externo). El drop-in de WP es vite.embed.config.ts.
+ *  `npm run dev` también sirve `/src/sdk/embed.ts` para que Replit lo cargue
+ *  en vivo (type=module) sin copiar source ni publicar el IIFE. */
 export default defineConfig({
   plugins: [react()],
   server: {
+    host: "0.0.0.0",
     allowedHosts: true,
+    cors: true,
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+    },
   },
   build: {
     lib: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Qué

Replit puede seguir sirviendo Fitspin V2 **sin** copiar `packages/react-sdk/src` y **sin** relanzar toda la app.

- `npm run dev` sirve `/src/sdk/embed.ts` con CORS abierto.
- Receta para pegarle al agente de Replit: `docs/v2-replit.md`.
- Env `GAFA_SDK_V2_URL` = Vite (en vivo) o `gafa-sdk.js` (snapshot).

No toca `master`. Base: `v2/main`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-05c170fe-fc4e-4b66-80d7-47eac7f51494?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05c170fe-fc4e-4b66-80d7-47eac7f51494&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

