### PR TITLE
fix(calendario): el filtro de sede sigue a ?location= y Todos muestra todas

### DIFF
--- a/packages/react-sdk/src/sdk/bootstrap/legacyBootstrap.tsx
+++ b/packages/react-sdk/src/sdk/bootstrap/legacyBootstrap.tsx
@@ -1,5 +1,6 @@
 import type { GafaSdk } from "../runtime";
 import type { CalendarView } from "../widgets/calendarRange";
+import { readCalendarLocationIdFromWindow } from "../widgets/calendarLocationQuery";
 
 type LegacyWidgetName =
   | "login"
@@ -79,7 +80,8 @@ function mountLegacyWidget(runtime: GafaSdk, widgetName: LegacyWidgetName, eleme
           staff: element.hasAttribute("filter-bq-staff"),
           room: element.hasAttribute("filter-bq-room"),
           brandId: toNumber(element.getAttribute("filter-bq-brand-default")),
-          locationId: toNumber(element.getAttribute("filter-bq-location-default")),
+          locationId:
+            readCalendarLocationIdFromWindow() ?? toNumber(element.getAttribute("filter-bq-location-default")),
           serviceId: toNumber(element.getAttribute("filter-bq-service-default")),
           staffId: toNumber(element.getAttribute("filter-bq-staff-default")),
         },

--- a/packages/react-sdk/src/sdk/widgets/CalendarWidget.tsx
+++ b/packages/react-sdk/src/sdk/widgets/CalendarWidget.tsx
@@ -35,6 +35,11 @@ import {
   type DateRange,
   type TimeOfDay,
 } from "./calendarRange";
+import {
+  calendarLocationSelectValue,
+  readCalendarLocationIdFromWindow,
+  resolveCalendarLocationId,
+} from "./calendarLocationQuery";
 
 export type CalendarWidgetProps = {
   client?: GafaClient;
@@ -62,7 +67,8 @@ export type CalendarWidgetProps = {
 
 type CalendarFiltersState = {
   brandSlug?: string;
-  locationId?: number;
+  /** `null` = el usuario eligió "Todos"; no reaplicar URL / default. */
+  locationId?: number | null;
   serviceId?: number;
   staffId?: number;
 };
@@ -82,7 +88,9 @@ export function CalendarWidget({
   description: _description,
 }: CalendarWidgetProps) {
   const queryClient = useQueryClient();
-  const [selectedFilters, setSelectedFilters] = useState<CalendarFiltersState>({});
+  const [selectedFilters, setSelectedFilters] = useState<CalendarFiltersState>(() => ({
+    locationId: readCalendarLocationIdFromWindow() ?? filters.locationId,
+  }));
   const [selectedMeeting, setSelectedMeeting] = useState<Meeting | null>(null);
   const [checkoutMeeting, setCheckoutMeeting] = useState<Meeting | null>(null);
   // Meeting que el usuario quiere reservar pero aun no tiene sesion: dispara el
@@ -247,9 +255,10 @@ export function CalendarWidget({
     return (brandsQuery.data ?? []).filter((brand) => slugs.has(brand.slug));
   }, [bookableLocations, brandsQuery.data]);
 
-  // undefined = "Todos" (como el calendar legacy). Solo se fija una sede si el
-  // sitio manda filters.locationId o el usuario elige una en el select.
-  const selectedLocationId = selectedFilters.locationId ?? filters.locationId;
+  // URL (?location=200) y filter-bq-location-default arrancan el select en esa
+  // sede. Si el usuario elige "Todos" (null) no se vuelve a aplicar ese default.
+  const locationFallbackId = readCalendarLocationIdFromWindow() ?? filters.locationId;
+  const selectedLocationId = resolveCalendarLocationId(selectedFilters.locationId, locationFallbackId);
   const showAllLocations = selectedLocationId == null;
 
   const activeLocation = useMemo(() => {
@@ -259,6 +268,13 @@ export function CalendarWidget({
     // El <select> solo tiene el representante (primer id) de cada nombre.
     return locations.find((location) => locationNameKey(location.name) === locationNameKey(match.name)) ?? match;
   }, [bookableLocations, locations, selectedLocationId, showAllLocations]);
+
+  const locationSelectValue =
+    selectedFilters.locationId === null
+      ? ""
+      : activeLocation
+        ? String(activeLocation.id)
+        : calendarLocationSelectValue(selectedFilters.locationId, locationFallbackId);
 
   const activeLocationGroup = useMemo(() => {
     if (showAllLocations) return bookableLocations;
@@ -274,7 +290,7 @@ export function CalendarWidget({
     if (selectedId == null) return;
     const stillThere = bookableLocations.some((location) => location.id === selectedId);
     if (!stillThere) {
-      setSelectedFilters((current) => ({ ...current, locationId: undefined }));
+      setSelectedFilters((current) => ({ ...current, locationId: null }));
     }
   }, [bookableLocations, bookableLocationsQuery.isSuccess, selectedFilters.locationId]);
 
@@ -642,6 +658,7 @@ export function CalendarWidget({
             filters={filters}
             loading={discoveringLocations}
             locations={locations}
+            locationSelectValue={locationSelectValue}
             onChange={(updater) => {
               allowAutoSkipRef.current = true;
               setSelectedFilters(updater);
@@ -1187,6 +1204,7 @@ function CalendarFilterBar({
   filters,
   loading = false,
   locations,
+  locationSelectValue,
   onChange,
   selected,
   serviceOptions,
@@ -1200,6 +1218,7 @@ function CalendarFilterBar({
   filters: NonNullable<CalendarWidgetProps["filters"]>;
   loading?: boolean;
   locations: Location[];
+  locationSelectValue: string;
   onChange: React.Dispatch<React.SetStateAction<CalendarFiltersState>>;
   selected: CalendarFiltersState;
   serviceOptions: Array<{ id: number; name: string }>;
@@ -1259,8 +1278,13 @@ function CalendarFilterBar({
           <LocationIcon />
           <select
             aria-label="Ubicación"
-            value={selected.locationId ?? ""}
-            onChange={(event) => onChange((current) => ({ ...current, locationId: toOptionalNumber(event.target.value) }))}
+            value={locationSelectValue}
+            onChange={(event) =>
+              onChange((current) => ({
+                ...current,
+                locationId: event.target.value === "" ? null : toOptionalNumber(event.target.value),
+              }))
+            }
           >
             <option value="">Todos</option>
             {locations.map((location) => (

--- a/packages/react-sdk/src/sdk/widgets/calendarLocationQuery.test.ts
+++ b/packages/react-sdk/src/sdk/widgets/calendarLocationQuery.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+  calendarLocationSelectValue,
+  readCalendarLocationIdFromSearch,
+  resolveCalendarLocationId,
+} from "./calendarLocationQuery";
+
+describe("readCalendarLocationIdFromSearch", () => {
+  it("lee ?location= numérico (Fitspin / Replit)", () => {
+    expect(readCalendarLocationIdFromSearch("?location=200")).toBe(200);
+    expect(readCalendarLocationIdFromSearch("location=200")).toBe(200);
+  });
+
+  it("acepta location_id y locationId", () => {
+    expect(readCalendarLocationIdFromSearch("?location_id=122")).toBe(122);
+    expect(readCalendarLocationIdFromSearch("?locationId=8")).toBe(8);
+  });
+
+  it("ignora valores no numéricos y ausentes", () => {
+    expect(readCalendarLocationIdFromSearch("?location=cancun")).toBeUndefined();
+    expect(readCalendarLocationIdFromSearch("?staff=1")).toBeUndefined();
+    expect(readCalendarLocationIdFromSearch("")).toBeUndefined();
+  });
+});
+
+describe("resolveCalendarLocationId", () => {
+  it("hereda el default de URL mientras el usuario no toca el select", () => {
+    expect(resolveCalendarLocationId(undefined, 200)).toBe(200);
+  });
+
+  it("respeta la sede que eligió el usuario", () => {
+    expect(resolveCalendarLocationId(91, 200)).toBe(91);
+  });
+
+  it("Todos explícito no vuelve a la sede de la URL", () => {
+    expect(resolveCalendarLocationId(null, 200)).toBeUndefined();
+  });
+});
+
+describe("calendarLocationSelectValue", () => {
+  it("pinta la sede de la URL, no Todos", () => {
+    expect(calendarLocationSelectValue(undefined, 200)).toBe("200");
+  });
+
+  it("pinta Todos cuando el usuario lo elige", () => {
+    expect(calendarLocationSelectValue(null, 200)).toBe("");
+  });
+});

--- a/packages/react-sdk/src/sdk/widgets/calendarLocationQuery.ts
+++ b/packages/react-sdk/src/sdk/widgets/calendarLocationQuery.ts
@@ -1,0 +1,47 @@
+/**
+ * Filtro de sede del calendario: la URL (`?location=200`) y
+ * `filter-bq-location-default` arrancan el select en esa sede.
+ *
+ * `undefined` = todavía no eligió (hereda URL/default).
+ * `null` = eligió "Todos" a propósito: no volver a caer en la URL.
+ */
+
+const LOCATION_QUERY_KEYS = ["location", "location_id", "locationId"] as const;
+
+export function readCalendarLocationIdFromSearch(search: string = ""): number | undefined {
+  const params = new URLSearchParams(search.startsWith("?") ? search.slice(1) : search);
+  for (const key of LOCATION_QUERY_KEYS) {
+    const raw = params.get(key);
+    if (!raw) continue;
+    const parsed = Number(raw);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
+}
+
+export function readCalendarLocationIdFromWindow(
+  win: { location?: { search?: string } } | undefined = typeof window === "undefined" ? undefined : window,
+): number | undefined {
+  return readCalendarLocationIdFromSearch(win?.location?.search ?? "");
+}
+
+/**
+ * Sede efectiva para pedir meetings y pintar el select.
+ * `null` gana: es "Todos" y no se reaplica el default de la URL.
+ */
+export function resolveCalendarLocationId(
+  selected: number | null | undefined,
+  fallback?: number,
+): number | undefined {
+  if (selected === null) return undefined;
+  return selected ?? fallback;
+}
+
+/** Valor del <select>: "" pinta "Todos". */
+export function calendarLocationSelectValue(
+  selected: number | null | undefined,
+  fallback?: number,
+): string {
+  const id = resolveCalendarLocationId(selected, fallback);
+  return id == null ? "" : String(id);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Qué

En Fitspin (`/reservar?location=200`) las clases ya salían de Cancún, pero el select de sede seguía en **Todos**. Elegir **Todos** volvía a aplicar el id de la URL.

## Cambio

- `?location=` (y `filter-bq-location-default`) arrancan el select en esa sede.
- **Todos** es un `null` explícito: no se vuelve a caer en la URL.
- 68 tests OK.

Base: `v2/main`. No toca `master`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-05c170fe-fc4e-4b66-80d7-47eac7f51494?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05c170fe-fc4e-4b66-80d7-47eac7f51494&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

